### PR TITLE
ci: refactor release workflow to follow release-plz recommended flow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
@@ -12,8 +12,80 @@ permissions:
   packages: write
 
 jobs:
-  build:
+  # Create a PR with the new versions and changelog, preparing the next release
+  release-plz-pr:
+    name: Release PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+
+      - name: Run release-plz (release-pr)
+        uses: release-plz/release-plz@57f50ec9b6e45004b1c4951a78e36dfe1db200dd # main
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Release unpublished packages
+  release-plz-release:
+    name: Release
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.extract_tag.outputs.tag }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+
+      - name: Run release-plz (release)
+        id: release
+        uses: release-plz/release-plz@57f50ec9b6e45004b1c4951a78e36dfe1db200dd # main
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Extract tag name
+        id: extract_tag
+        if: steps.release.outputs.releases_created == 'true'
+        run: |
+          # Get the latest tag created by release-plz
+          tag=$(git describe --tags --abbrev=0)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Created release tag: $tag"
+
+  # Build binaries for multiple platforms (only when release is created)
+  build-binaries:
     name: Build ${{ matrix.target }}
+    needs: release-plz-release
+    if: needs.release-plz-release.outputs.release_created == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -104,21 +176,13 @@ jobs:
           path: ofsht-${{ matrix.target }}.${{ matrix.archive_suffix }}
           if-no-files-found: error
 
-  release:
-    name: Create Release
-    needs: build
+  # Attach binaries to GitHub Release
+  attach-assets:
+    name: Attach Release Assets
+    needs: [release-plz-release, build-binaries]
+    if: needs.release-plz-release.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-        with:
-          fetch-depth: 0
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-
       - name: Download all artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -130,32 +194,12 @@ jobs:
           find artifacts -type f -name "*.tar.gz" -exec mv {} release-assets/ \;
           ls -lh release-assets/
 
-      - name: Run release-plz
-        id: release_plz
-        run: |
-          set -euo pipefail
-
-          # Install release-plz
-          cargo install release-plz --locked
-
-          # Run release-plz and capture JSON output
-          release-plz release -o json > release-plz.json
-          cat release-plz.json
-
-          # Extract tag from JSON output
-          tag=$(jq -r '.releases[0].tag' release-plz.json)
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "Release tag: $tag"
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLZ_GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          tag="${{ steps.release_plz.outputs.tag }}"
+          tag="${{ needs.release-plz-release.outputs.tag_name }}"
 
           # Upload all assets to the draft release
           gh release upload "$tag" release-assets/* \
@@ -169,7 +213,7 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_PLZ_GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          tag="${{ steps.release_plz.outputs.tag }}"
+          tag="${{ needs.release-plz-release.outputs.tag_name }}"
 
           # Check that exactly 4 assets were uploaded
           asset_count=$(gh release view "$tag" --json assets --jq '.assets | length')
@@ -187,7 +231,7 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_PLZ_GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          tag="${{ steps.release_plz.outputs.tag }}"
+          tag="${{ needs.release-plz-release.outputs.tag_name }}"
 
           # Publish the draft release
           gh release edit "$tag" --draft=false --latest

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -14,33 +14,38 @@ Releases are fully automated using [release-plz](https://release-plz.ieni.dev/) 
 
 ## Release Workflow
 
-### Automatic Release (Current Setup)
+### Fully Automated Release Process
+
+The release process is **completely automated** using release-plz. You don't need to manually create tags or trigger workflows.
+
+#### How It Works
 
 1. **Development**: Work on features/fixes on feature branches
 2. **Commit**: Use Conventional Commits format (see below)
 3. **Merge to main**: Merge pull requests to the main branch
-4. **Tag**: Create and push a version tag
-5. **Automation**: GitHub Actions automatically:
-   - Builds binaries for all platforms
-   - Publishes to crates.io
-   - Creates GitHub Release with assets
-   - Updates CHANGELOG.md
+4. **Automatic Release PR Creation**:
+   - GitHub Actions automatically creates/updates a release PR
+   - The PR includes version bumps and CHANGELOG updates
+   - Review the release PR to verify changes
+5. **Merge Release PR**: Once approved, merge the release PR
+6. **Automatic Publishing**:
+   - GitHub Actions automatically publishes to crates.io
+   - Builds binaries for all platforms (Linux GNU/MUSL, macOS x86_64/ARM64)
+   - Creates GitHub Release with binary assets
+   - Tags the release
 
-### Triggering a Release
+#### Workflow Jobs
 
-```bash
-# Ensure main branch is up to date
-git checkout main
-git pull origin main
+The `.github/workflows/release.yaml` workflow runs on every push to `main`:
 
-# Create a version tag (must start with 'v')
-git tag v0.2.0
+1. **`release-plz-pr`**: Creates/updates a release PR with version bumps and CHANGELOG
+2. **`release-plz-release`**: Publishes unpublished packages to crates.io
+3. **`build-binaries`**: Builds cross-platform binaries (only when a release is created)
+4. **`attach-assets`**: Attaches binaries to the GitHub Release and publishes it
 
-# Push the tag to trigger release workflow
-git push origin v0.2.0
-```
+### No Manual Tag Creation Needed
 
-The `.github/workflows/release.yaml` workflow will automatically start.
+Unlike traditional workflows, you **do not** need to manually create or push version tags. The release-plz automation handles this automatically when you merge the release PR.
 
 ## Conventional Commits
 


### PR DESCRIPTION
## Summary

This PR refactors the release workflow to follow the official release-plz recommended pattern, fixing the issue where merging to main did not trigger any automation.

### Background

The initial implementation used a tag-based trigger (`push: tags: v*`), which required manual tag creation and did not align with release-plz's automated workflow. This meant:
- Merging PRs to main did nothing
- Release PRs were never automatically created
- Manual intervention was always required

### Changes

**1. Trigger Change**
- **Before**: `push: tags: v*` (manual tag creation required)
- **After**: `push: branches: main` (fully automated)

**2. Four-Job Structure** (following official quickstart)

1. **`release-plz-pr`**: 
   - Creates/updates release PRs automatically on every main push
   - Includes version bumps and CHANGELOG updates
   - Uses concurrency control to prevent PR conflicts

2. **`release-plz-release`**: 
   - Publishes unpublished packages to crates.io
   - Creates draft GitHub Releases
   - Outputs release metadata for downstream jobs

3. **`build-binaries`**: 
   - Builds 4-target binaries (Linux GNU/MUSL, macOS x86_64/ARM64)
   - **Only runs when a release is actually created** (conditional execution)
   - Prevents wasteful builds on non-release merges

4. **`attach-assets`**: 
   - Downloads built artifacts
   - Attaches binaries to GitHub Release using `gh` CLI
   - Verifies 4 assets are present
   - Publishes the draft release

**3. Use Official Action**
- Switched from `cargo install release-plz` to `release-plz/release-plz@<SHA>`
- Proper `persist-credentials: false` for security
- Commit SHA pinning maintained

**4. Security Improvements**
- All actions pinned to commit SHAs
- `release-plz/release-plz@57f50ec9b6e45004b1c4951a78e36dfe1db200dd`
- Continued use of GitHub CLI (`gh`) instead of third-party actions
- Maintained asset verification step

### New Workflow

```
Merge PR to main
  ↓
[Parallel execution]
├─ release-plz-pr: Create/update release PR
└─ release-plz-release: Publish if unpublished versions exist
     ↓ (only if release created)
   build-binaries: Build 4 targets
     ↓
   attach-assets: Attach & publish
```

### Breaking Changes

None. The workflow now works as originally intended—fully automated releases without manual tag creation.

## References

- [release-plz Quickstart](https://release-plz.dev/docs/github/quickstart)
- [release-plz Configuration](https://release-plz.dev/docs/config)
- [GitHub Actions: Concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency)