### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2025-11-23
+
+### Breaking Changes
+
+- Extract tag from release-plz output instead of git describe
+
+
 ### Changed
 - **BREAKING**: Replaced Makefile with justfile for task running
   - **Migration**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "ofsht"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ofsht"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["wadackel"]
 description = "Git worktree management tool"


### PR DESCRIPTION



## 🤖 New release

* `ofsht`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1] - 2025-11-23

### Breaking Changes

- Extract tag from release-plz output instead of git describe


### Changed
- **BREAKING**: Replaced Makefile with justfile for task running
  - **Migration**:
    - Install mise: `brew install mise` (or see [mise installation guide](https://mise.jdx.dev/getting-started.html))
    - Install just: `mise install` (version pinned to 1.43.1 in mise.toml)
    - Use `just check` instead of `make check`
    - See `just --list` for all available commands
  - **Rationale**: Better cross-platform support, improved UX, and local/CI environment parity

### Added
- mise configuration for reproducible development environments
- Dependabot for automated dependency updates of GitHub Actions and Cargo
- Separate fast (`just test`) and CI-equivalent (`just test-ci`) commands
- Support for removing prunable worktrees (directories manually deleted)
  - `ofsht rm` can now remove worktrees even if their directories no longer exist
  - Works with branch names, absolute paths, and relative paths
  - Git marks these as "prunable" and ofsht handles them gracefully

### Security
- GitHub Actions now use SHA-pinned mise-action with fixed mise version (2025.11.5)
- Removed unnecessary `checks: write` permission from CI workflow
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).