### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2025-11-23
+
+### Breaking Changes
+
+- Use correct output name for release-plz releases
+
+
 ## [0.1.2] - 2025-11-23
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "ofsht"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ofsht"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["wadackel"]
 description = "Git worktree management tool"


### PR DESCRIPTION



## 🤖 New release

* `ofsht`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3] - 2025-11-23

### Breaking Changes

- Use correct output name for release-plz releases
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).