### PR TITLE
refactor: replace third-party rust-toolchain action with composite action

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -1,0 +1,52 @@
+name: Setup Rust Toolchain
+description: Setup Rust toolchain using rustup without third-party actions
+
+inputs:
+  toolchain:
+    description: 'Rust toolchain version (e.g., stable, nightly, 1.70.0)'
+    required: false
+    default: 'stable'
+  components:
+    description: 'Comma-separated list of components (e.g., clippy,rustfmt)'
+    required: false
+    default: ''
+  targets:
+    description: 'Comma-separated list of targets (e.g., x86_64-unknown-linux-musl)'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Rust toolchain
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # Update and set default toolchain
+        rustup update ${{ inputs.toolchain }} --no-self-update
+        rustup default ${{ inputs.toolchain }}
+
+        # Add components if specified
+        if [[ -n "${{ inputs.components }}" ]]; then
+          IFS=',' read -ra COMPONENTS <<< "${{ inputs.components }}"
+          for component in "${COMPONENTS[@]}"; do
+            component=$(echo "$component" | xargs)  # Trim whitespace
+            echo "Adding component: $component"
+            rustup component add "$component"
+          done
+        fi
+
+        # Add targets if specified
+        if [[ -n "${{ inputs.targets }}" ]]; then
+          IFS=',' read -ra TARGETS <<< "${{ inputs.targets }}"
+          for target in "${TARGETS[@]}"; do
+            target=$(echo "$target" | xargs)  # Trim whitespace
+            echo "Adding target: $target"
+            rustup target add "$target"
+          done
+        fi
+
+        # Display installed toolchain info
+        rustc --version
+        cargo --version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,9 +38,8 @@ jobs:
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
           components: clippy,rustfmt
 
       - name: Setup mise

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,9 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
+        uses: ./.github/actions/setup-rust
 
       # Generate short-lived token from GitHub App
       # Token generation after checkout follows official release-plz best practices
@@ -76,9 +74,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
+        uses: ./.github/actions/setup-rust
 
       - name: Run release-plz (release)
         id: release
@@ -143,9 +139,8 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
           targets: ${{ matrix.target }}
 
       - name: Install cross-compilation tools


### PR DESCRIPTION
## Summary

Replace `dtolnay/rust-toolchain` action with custom composite action to reduce third-party dependencies and centralize Rust toolchain setup.

## Changes

- **Created** `.github/actions/setup-rust/action.yaml` composite action
  - Supports configurable `toolchain`, `components`, and `targets` inputs
  - Uses native `rustup` commands internally
- **Updated** 4 workflow locations to use the new composite action:
  - `ci.yaml`: CI quality checks (with `clippy` and `rustfmt` components)
  - `release.yaml` (release-plz-pr): Release PR creation (default settings)
  - `release.yaml` (release-plz-release): Release execution (default settings)
  - `release.yaml` (build-binaries): Multi-platform builds (with `targets` matrix)

## Benefits

- ✅ Eliminates third-party action dependency
- ✅ Centralized configuration in one reusable action
- ✅ Maintains all existing functionality
- ✅ All tests pass locally (`just check`)

## Test Plan

- [x] Local verification: `just check` passes
- [ ] CI verification: All workflow jobs pass on this PR
- [ ] Release workflow verification: (will be tested on next release)

## Technical Details

The composite action uses the following rustup commands:
```bash
rustup update <toolchain> --no-self-update
rustup default <toolchain>
rustup component add <components>  # if specified
rustup target add <targets>        # if specified
```

Ubuntu 22.04 GitHub Actions runners have Rust preinstalled, so this approach works without additional setup.