### PR TITLE
docs: add mise installation support via ubi backend

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -178,6 +178,10 @@ jobs:
       - name: Strip binary
         run: ${{ matrix.strip }} target/${{ matrix.target }}/release/ofsht
 
+      # IMPORTANT: Asset naming format is critical for mise ubi backend compatibility
+      # Format: ofsht-${target}.tar.gz containing single ofsht binary at root
+      # Changes to naming or archive structure will break mise installations
+      # See CONTRIBUTING.md "mise ubi Distribution" section for details
       - name: Create archive
         run: |
           cd target/${{ matrix.target }}/release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,11 @@ curl https://mise.run | sh
 
 **Other platforms**: See [mise installation guide](https://mise.jdx.dev/getting-started.html)
 
+> [!TIP]
+> **Dogfooding**: ofsht itself is also installable via mise: `mise use -g ubi:wadackel/ofsht`
+>
+> Note: `mise install` (without arguments) only installs development tools from `mise.toml` (just, vhs). Installing ofsht via mise is optional and requires the explicit `mise use -g` command above.
+
 #### Installing Development Tools
 
 After installing mise:
@@ -549,6 +554,29 @@ The Homebrew tap (`wadackel/homebrew-tap`) is automatically updated on each rele
 - The main release will still succeed even if tap update fails
 - Tap updates can be triggered manually via the tap repository's Actions tab
 - Required secret: `HOMEBREW_TAP_TOKEN` (PAT with workflow permissions)
+
+### mise ubi Distribution
+
+ofsht binaries are automatically compatible with mise's [ubi backend](https://mise.jdx.dev/dev-tools/backends/ubi.html):
+
+```bash
+mise use -g ubi:wadackel/ofsht
+```
+
+**How it works**:
+1. mise's ubi backend reads GitHub releases directly from this repository
+2. Automatically detects the user's platform (OS + CPU architecture)
+3. Downloads and extracts the appropriate binary from release assets
+4. No maintainer action or registry registration required
+
+**Requirements** (already met):
+- ✅ Asset naming follows platform conventions: `ofsht-${target}.tar.gz`
+- ✅ Archive contains single executable at root level
+- ✅ Supported platforms: Linux (x86_64 gnu/musl), macOS (x86_64/aarch64)
+
+**Important**: Asset naming is critical for mise compatibility. The release workflow (`.github/workflows/release.yaml:181-185`) generates archives in the format `ofsht-{target}.tar.gz` containing a single `ofsht` binary. Changing this format will break mise installations.
+
+**Registry decision**: We intentionally do NOT register ofsht in the [mise registry](https://mise.jdx.dev/registry.html). The ubi backend works perfectly without registration, and users can install via `ubi:wadackel/ofsht` directly. This avoids the maintenance burden of keeping a registry entry updated.
 
 ### Manual Release
 

--- a/README.md
+++ b/README.md
@@ -62,11 +62,40 @@ A command-line tool for managing Git worktrees with automation features.
 
 ## Installation
 
-### From crates.io (Recommended)
+### From crates.io
 
 ```bash
 cargo install ofsht
 ```
+
+### From Homebrew
+
+```bash
+brew install wadackel/tap/ofsht
+```
+
+### Using mise
+
+If you're using [mise](https://mise.jdx.dev/) for development tool management:
+
+```bash
+# Install latest version
+mise use -g ubi:wadackel/ofsht
+
+# Or install specific version
+mise install ubi:wadackel/ofsht@0.1.7
+
+# Or add to mise.toml
+[tools]
+"ubi:wadackel/ofsht" = "latest"
+```
+
+This method works via mise's ubi backend, which automatically:
+- Detects your platform and downloads the appropriate binary
+- Manages versions alongside your other development tools
+- Works without requiring ofsht to be in the mise registry
+
+**Supported platforms**: Linux (x86_64), macOS (Intel/Apple Silicon)
 
 ### From Binary Releases
 
@@ -84,12 +113,6 @@ sudo mv ofsht /usr/local/bin/
 # Linux (x86_64)
 curl -L https://github.com/wadackel/ofsht/releases/latest/download/ofsht-x86_64-unknown-linux-gnu.tar.gz | tar xz
 sudo mv ofsht /usr/local/bin/
-```
-
-### From Homebrew
-
-```bash
-brew install wadackel/tap/ofsht
 ```
 
 ### From Source


### PR DESCRIPTION
## Summary

This PR adds documentation for installing ofsht via [mise](https://mise.jdx.dev/)'s ubi backend.

**Key finding**: ofsht is already fully compatible with mise ubi backend - no code changes required. The existing release process (GitHub releases with properly named binaries) works out of the box.

**Verified working**:
```bash
mise install ubi:wadackel/ofsht@0.1.7  # ✅ Successfully tested
```

### Changes

1. **README.md** - Added mise installation section
   - Documented installation via `mise use -g ubi:wadackel/ofsht`
   - Listed supported platforms: Linux (x86_64), macOS (Intel/Apple Silicon)
   - Explicitly excluded Windows (not currently supported)

2. **CONTRIBUTING.md** - Added mise setup and distribution documentation
   - Prerequisites: Added dogfooding tip for installing ofsht via mise
   - Release Process: New "mise ubi Distribution" section explaining:
     - How mise ubi backend works
     - Critical requirements (asset naming, archive structure)
     - Registry decision (intentionally not registering in mise registry)

3. **`.github/workflows/release.yaml`** - Added critical comment
   - Documented that asset naming format is critical for mise compatibility
   - Prevents future changes from accidentally breaking mise installations

### Technical Details

**mise ubi backend requirements** (all already met):
- ✅ Asset naming: `ofsht-${target}.tar.gz` (Rust target triple format)
- ✅ Archive structure: Single `ofsht` binary at root level
- ✅ Platform detection: OS + architecture in filename (darwin/linux, x86_64/aarch64)

**Why no registry registration**:
- ubi backend works perfectly without registry entry
- Zero maintenance burden (no extra repo/formula to maintain)
- Users can install via `ubi:wadackel/ofsht` directly

### Impact

- ✅ No code changes (documentation only)
- ✅ No breaking changes
- ✅ Zero maintenance cost (automatic compatibility)
- ✅ All tests pass (`just check`)

## References

- [mise ubi Backend Documentation](https://mise.jdx.dev/dev-tools/backends/ubi.html)
- [Universal Binary Installer (ubi) Repository](https://github.com/houseabsolute/ubi)
- [mise Registry](https://mise.jdx.dev/registry.html) (intentionally not using)