### PR TITLE
ci: resolve release-plz authentication failure with GitHub App token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,10 +36,6 @@ jobs:
       - name: Install Rust toolchain
         uses: ./.github/actions/setup-rust
 
-      # Generate short-lived token from GitHub App
-      # Token generation after checkout follows official release-plz best practices
-      # Matches official configuration: permission-based token (no owner/repositories)
-      # SHA-pinned to v2.2.0 for supply chain security
       - name: Generate GitHub App token
         id: release-token
         uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
@@ -76,13 +72,21 @@ jobs:
       - name: Install Rust toolchain
         uses: ./.github/actions/setup-rust
 
+      - name: Generate GitHub App token
+        id: release-token
+        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
+        with:
+          app-id: ${{ vars.OFSHT_APP_ID }}
+          private-key: ${{ secrets.OFSHT_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Run release-plz (release)
         id: release
-        uses: release-plz/action@e1f28dee02b4eecdd2b43b8b868e5acee45334a0 # v0.5.101
+        uses: release-plz/action@d529f731ae3e89610ada96eda34e5c6ba3b12214 # v0.5.118
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Extract tag name


### PR DESCRIPTION
## Summary

This PR fixes the release-plz release job authentication failure that occurred after migrating to GitHub App authentication. The root cause was that the `release-plz-release` job was still using the old workflow token (`secrets.GITHUB_TOKEN`) and an outdated action version (`v0.5.101`).

**Problem**: The release job failed with `fatal: could not read Username for 'https://github.com'` because Git credentials were not properly configured for pushing tags.

**Solution**:
1. **Unified action versions**: Updated `release-plz-release` to use `v0.5.118` (same as `release-plz-pr`)
2. **GitHub App token integration**: Added GitHub App token generation step to the release job
3. **Consistent authentication**: Both PR and release jobs now use the same GitHub App-based authentication flow

The newer version of `release-plz/action` (v0.5.118) properly handles Git authentication internally when provided with a GitHub App token, eliminating the authentication errors.

## References

- Failed job: https://github.com/wadackel/ofsht/actions/runs/19623269217/job/56187489901
- release-plz documentation: https://release-plz.ieni.dev/docs/github/introduction