### PR TITLE
ci: migrate to crates.io Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,6 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ steps.release-token.outputs.token }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   # Release unpublished packages
   release-plz-release:
@@ -62,6 +61,7 @@ jobs:
       tag_name: ${{ steps.extract_tag.outputs.tag }}
     permissions:
       contents: write
+      id-token: write  # Required for OIDC token minting
     steps:
       - name: Checkout repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -80,6 +80,10 @@ jobs:
           private-key: ${{ secrets.OFSHT_APP_PRIVATE_KEY }}
           permission-contents: write
 
+      - name: Authenticate with crates.io
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
+
       - name: Run release-plz (release)
         id: release
         uses: release-plz/action@d529f731ae3e89610ada96eda34e5c6ba3b12214 # v0.5.118
@@ -87,7 +91,7 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ steps.release-token.outputs.token }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
 
       - name: Extract tag name
         id: extract_tag


### PR DESCRIPTION
## Summary

Migrate from legacy API token authentication to OIDC-based Trusted Publishing for secure, tokenless crates.io publishing.

## Changes

- **Remove** `CARGO_REGISTRY_TOKEN` from `release-plz-pr` job (not needed for PR creation)
- **Add** `id-token: write` permission to `release-plz-release` job for OIDC token minting
- **Add** `rust-lang/crates-io-auth-action@v1.0.3` step (SHA-pinned: `b7e9a28`)
- **Change** `CARGO_REGISTRY_TOKEN` to use short-lived OIDC token from auth action

## Security Benefits

| Aspect | Before (API Token) | After (Trusted Publishing) |
|--------|-------------------|----------------------------|
| **Token Management** | Manual secret rotation | Automatic per-job tokens |
| **Token Lifetime** | Unlimited (until revoked) | ~10 minutes (OIDC exchange) |
| **Security Risk** | High (static secret exposure) | Low (ephemeral tokens) |
| **Scope** | Global crates.io access | Repository-specific publishing |

## Prerequisites

✅ Trusted Publishing configured on crates.io:
- GitHub Owner: `wadackel`
- Repository: `ofsht`
- Workflow: `.github/workflows/release.yaml`

## Test Plan

After merging:
1. Wait for release-plz to create release PR (automatic)
2. Merge release PR to trigger publish
3. Verify OIDC authentication in `release-plz-release` job logs
4. Verify new version appears on crates.io
5. Verify GitHub Release created with 4 binary assets
6. Delete `CARGO_REGISTRY_TOKEN` secret from repository settings

## Rollback Plan

If OIDC authentication fails:
- Revert this PR
- Re-add `CARGO_REGISTRY_TOKEN` secret temporarily
- Investigate crates.io Trusted Publishing configuration

## References

- [crates.io Trusted Publishing](https://crates.io/docs/trusted-publishing)
- [rust-lang/crates-io-auth-action](https://github.com/rust-lang/crates-io-auth-action)
- [Rust Blog: Trusted Publishing](https://blog.rust-lang.org/2025/07/11/crates-io-development-update-2025-07/)