### PR TITLE
docs: update Homebrew tap authentication documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -553,7 +553,11 @@ The Homebrew tap (`wadackel/homebrew-tap`) is automatically updated on each rele
 - If the tap update fails, check the [tap repository actions](https://github.com/wadackel/homebrew-tap/actions)
 - The main release will still succeed even if tap update fails
 - Tap updates can be triggered manually via the tap repository's Actions tab
-- Required secret: `HOMEBREW_TAP_TOKEN` (PAT with workflow permissions)
+- Required secrets/variables:
+  - `OFSHT_APP_ID` (variable): GitHub App ID for tap repository access
+  - `OFSHT_APP_PRIVATE_KEY` (secret): GitHub App private key
+  - GitHub App must be installed on both `ofsht` and `homebrew-tap` repositories
+  - GitHub App permissions required: actions (read/write), contents (read)
 
 ### mise ubi Distribution
 


### PR DESCRIPTION
## Summary

This PR updates the CONTRIBUTING.md documentation to reflect the current GitHub App-based authentication system used for Homebrew tap updates. The previous documentation referenced an obsolete `HOMEBREW_TAP_TOKEN` (PAT-based authentication) that is no longer used in the actual workflow implementation.

**Changes:**
- Removed outdated `HOMEBREW_TAP_TOKEN` reference
- Added detailed documentation for GitHub App authentication requirements:
  - `OFSHT_APP_ID` (variable): GitHub App ID for tap repository access
  - `OFSHT_APP_PRIVATE_KEY` (secret): GitHub App private key
  - Installation requirements for both repositories
  - Required permissions (actions read/write, contents read)

**Background:**
The release workflow (`.github/workflows/release.yaml`) has been using GitHub App tokens since the initial implementation of the Homebrew tap update automation. This provides better security through:
- Repository-scoped permissions
- Automatic token rotation per workflow run
- 1-hour token expiration
- Clear audit trail via GitHub App activity logs

This documentation update ensures contributors have accurate information about the authentication setup required for the Homebrew tap workflow.

## References

- `.github/workflows/release.yaml` (lines 270-387): Current implementation using GitHub App authentication