### PR TITLE
feat(completion): hide flag candidates until the user types `-`

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,8 +554,10 @@ source (COMPLETE=fish ofsht | psub)
 
 After setup, you'll get intelligent completions:
 - `ofsht add feature <TAB>` - When specifying a start point, lists branches, remote refs, and tags
-- `ofsht rm <TAB>` - Lists worktree names (and flags, following standard CLI conventions)
+- `ofsht rm <TAB>` - Lists worktree names
 - `ofsht cd <TAB>` - Lists worktree names
+
+Global and subcommand flags are suggested only after the current word starts with `-` (e.g., `ofsht cd -<TAB>`).
 
 ## Common Workflows
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,13 +7,15 @@ mod domain;
 mod hooks;
 mod integrations;
 mod service;
+mod shell_completion;
 
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
-use clap_complete::env::CompleteEnv;
+use clap_complete::env::{CompleteEnv, Shells};
 
 // Use shared CLI definitions from cli module
 use cli::{Cli, Commands};
+use shell_completion::{FilteredBash, FilteredFish, FilteredZsh};
 
 #[cfg(test)]
 use {
@@ -24,8 +26,11 @@ use {
 };
 
 fn main() -> Result<()> {
-    // Handle dynamic completion via COMPLETE environment variable
-    CompleteEnv::with_factory(Cli::command).complete();
+    // Handle dynamic completion via COMPLETE environment variable.
+    // Custom shell adapters hide flag candidates unless the current word starts with `-`.
+    CompleteEnv::with_factory(Cli::command)
+        .shells(Shells(&[&FilteredBash, &FilteredZsh, &FilteredFish]))
+        .complete();
 
     let cli = Cli::parse();
 

--- a/src/shell_completion.rs
+++ b/src/shell_completion.rs
@@ -1,0 +1,377 @@
+//! Custom shell completion adapters that hide flag candidates unless the current word starts with `-`.
+//!
+//! Wraps `clap_complete`'s built-in `EnvCompleter` implementations (Bash/Zsh/Fish) and post-filters
+//! the candidate list returned from `clap_complete::engine::complete`, removing entries whose value
+//! starts with `-` when the user has not yet typed a dash.
+
+use std::ffi::{OsStr, OsString};
+use std::io::{self, Write};
+use std::path::Path;
+
+use clap::Command;
+use clap_complete::engine::{complete, CompletionCandidate};
+use clap_complete::env::{Bash, EnvCompleter, Fish, Zsh};
+
+/// Drop flag candidates (values starting with `-`) unless the current word also starts with `-`.
+fn filter_flag_candidates(
+    completions: Vec<CompletionCandidate>,
+    current_word: &OsStr,
+) -> Vec<CompletionCandidate> {
+    if current_word.to_string_lossy().starts_with('-') {
+        return completions;
+    }
+    completions
+        .into_iter()
+        .filter(|c| !c.get_value().to_string_lossy().starts_with('-'))
+        .collect()
+}
+
+/// Run `engine::complete` and apply the flag filter against the current word at `args[index]`.
+fn filtered_candidates(
+    cmd: &mut Command,
+    args: Vec<OsString>,
+    index: usize,
+    current_dir: Option<&Path>,
+) -> io::Result<Vec<CompletionCandidate>> {
+    let current_word = args.get(index).cloned().unwrap_or_default();
+    let completions = complete(cmd, args, index, current_dir)?;
+    Ok(filter_flag_candidates(completions, &current_word))
+}
+
+/// Bash adapter: identical registration to the built-in, filtered completion output.
+pub struct FilteredBash;
+
+impl EnvCompleter for FilteredBash {
+    fn name(&self) -> &'static str {
+        "bash"
+    }
+
+    fn is(&self, name: &str) -> bool {
+        name == "bash"
+    }
+
+    fn write_registration(
+        &self,
+        var: &str,
+        name: &str,
+        bin: &str,
+        completer: &str,
+        buf: &mut dyn Write,
+    ) -> io::Result<()> {
+        Bash.write_registration(var, name, bin, completer, buf)
+    }
+
+    fn write_complete(
+        &self,
+        cmd: &mut Command,
+        args: Vec<OsString>,
+        current_dir: Option<&Path>,
+        buf: &mut dyn Write,
+    ) -> io::Result<()> {
+        let index: usize = std::env::var("_CLAP_COMPLETE_INDEX")
+            .ok()
+            .and_then(|i| i.parse().ok())
+            .unwrap_or_default();
+        let ifs: Option<String> = std::env::var("_CLAP_IFS").ok();
+        let filtered = filtered_candidates(cmd, args, index, current_dir)?;
+        for (i, candidate) in filtered.iter().enumerate() {
+            if i != 0 {
+                write!(buf, "{}", ifs.as_deref().unwrap_or("\n"))?;
+            }
+            write!(buf, "{}", candidate.get_value().to_string_lossy())?;
+        }
+        Ok(())
+    }
+}
+
+/// Zsh adapter: identical registration, filtered output, preserves `value:help` display format.
+pub struct FilteredZsh;
+
+impl EnvCompleter for FilteredZsh {
+    fn name(&self) -> &'static str {
+        "zsh"
+    }
+
+    fn is(&self, name: &str) -> bool {
+        name == "zsh"
+    }
+
+    fn write_registration(
+        &self,
+        var: &str,
+        name: &str,
+        bin: &str,
+        completer: &str,
+        buf: &mut dyn Write,
+    ) -> io::Result<()> {
+        Zsh.write_registration(var, name, bin, completer, buf)
+    }
+
+    fn write_complete(
+        &self,
+        cmd: &mut Command,
+        args: Vec<OsString>,
+        current_dir: Option<&Path>,
+        buf: &mut dyn Write,
+    ) -> io::Result<()> {
+        let index: usize = std::env::var("_CLAP_COMPLETE_INDEX")
+            .ok()
+            .and_then(|i| i.parse().ok())
+            .unwrap_or_default();
+        let ifs: Option<String> = std::env::var("_CLAP_IFS").ok();
+
+        // Match built-in Zsh: if current word is one beyond the last arg, pad with "".
+        // Source: clap_complete-4.5.60/src/env/shells.rs:410-414
+        let mut args = args;
+        if args.len() == index {
+            args.push(OsString::new());
+        }
+
+        let filtered = filtered_candidates(cmd, args, index, current_dir)?;
+        for (i, candidate) in filtered.iter().enumerate() {
+            if i != 0 {
+                write!(buf, "{}", ifs.as_deref().unwrap_or("\n"))?;
+            }
+            write!(
+                buf,
+                "{}",
+                escape_zsh_value(&candidate.get_value().to_string_lossy())
+            )?;
+            if let Some(help) = candidate.get_help() {
+                write!(
+                    buf,
+                    ":{}",
+                    escape_zsh_help(help.to_string().lines().next().unwrap_or_default())
+                )?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Zsh escape: backslash and colon are special within `value:help` records.
+/// Source: clap_complete-4.5.60/src/env/shells.rs:440-442
+fn escape_zsh_value(s: &str) -> String {
+    s.replace('\\', "\\\\").replace(':', "\\:")
+}
+
+/// Zsh help escape: only backslash needs doubling (colon already split by caller).
+/// Source: clap_complete-4.5.60/src/env/shells.rs:445-447
+fn escape_zsh_help(s: &str) -> String {
+    s.replace('\\', "\\\\")
+}
+
+/// Fish adapter: identical registration, filtered output, `value\thelp\n` per record.
+pub struct FilteredFish;
+
+impl EnvCompleter for FilteredFish {
+    fn name(&self) -> &'static str {
+        "fish"
+    }
+
+    fn is(&self, name: &str) -> bool {
+        name == "fish"
+    }
+
+    fn write_registration(
+        &self,
+        var: &str,
+        name: &str,
+        bin: &str,
+        completer: &str,
+        buf: &mut dyn Write,
+    ) -> io::Result<()> {
+        Fish.write_registration(var, name, bin, completer, buf)
+    }
+
+    fn write_complete(
+        &self,
+        cmd: &mut Command,
+        args: Vec<OsString>,
+        current_dir: Option<&Path>,
+        buf: &mut dyn Write,
+    ) -> io::Result<()> {
+        // Match built-in Fish: current word is the last arg.
+        // Source: clap_complete-4.5.60/src/env/shells.rs:237
+        let index = args.len().saturating_sub(1);
+        let filtered = filtered_candidates(cmd, args, index, current_dir)?;
+        for candidate in &filtered {
+            write!(buf, "{}", candidate.get_value().to_string_lossy())?;
+            if let Some(help) = candidate.get_help() {
+                write!(
+                    buf,
+                    "\t{}",
+                    help.to_string().lines().next().unwrap_or_default()
+                )?;
+            }
+            writeln!(buf)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::Cli;
+    use clap::CommandFactory;
+    use serial_test::serial;
+    use std::ffi::OsString;
+
+    fn cand(value: &str) -> CompletionCandidate {
+        CompletionCandidate::new(value)
+    }
+
+    #[test]
+    fn filter_drops_flags_when_current_word_empty() {
+        let completions = vec![
+            cand("@"),
+            cand("feature"),
+            cand("--color"),
+            cand("--help"),
+            cand("-v"),
+        ];
+        let filtered = filter_flag_candidates(completions, OsStr::new(""));
+        let values: Vec<&str> = filtered
+            .iter()
+            .map(|c| c.get_value().to_str().unwrap())
+            .collect();
+        assert_eq!(values, vec!["@", "feature"]);
+    }
+
+    #[test]
+    fn filter_keeps_all_when_current_word_is_dash() {
+        let completions = vec![cand("@"), cand("--color"), cand("-v")];
+        let filtered = filter_flag_candidates(completions, OsStr::new("-"));
+        let values: Vec<&str> = filtered
+            .iter()
+            .map(|c| c.get_value().to_str().unwrap())
+            .collect();
+        assert_eq!(values, vec!["@", "--color", "-v"]);
+    }
+
+    #[test]
+    fn filter_keeps_all_when_current_word_is_long_prefix() {
+        let completions = vec![cand("@"), cand("--color"), cand("--verbose")];
+        let filtered = filter_flag_candidates(completions, OsStr::new("--c"));
+        let values: Vec<&str> = filtered
+            .iter()
+            .map(|c| c.get_value().to_str().unwrap())
+            .collect();
+        assert_eq!(values, vec!["@", "--color", "--verbose"]);
+    }
+
+    #[test]
+    fn filter_drops_dashes_when_current_word_is_non_dash_text() {
+        let completions = vec![cand("@"), cand("feature"), cand("--color"), cand("-v")];
+        let filtered = filter_flag_candidates(completions, OsStr::new("foo"));
+        let values: Vec<&str> = filtered
+            .iter()
+            .map(|c| c.get_value().to_str().unwrap())
+            .collect();
+        assert_eq!(values, vec!["@", "feature"]);
+    }
+
+    fn values_of(candidates: &[CompletionCandidate]) -> Vec<String> {
+        candidates
+            .iter()
+            .map(|c| c.get_value().to_string_lossy().into_owned())
+            .collect()
+    }
+
+    fn args(parts: &[&str]) -> Vec<OsString> {
+        parts.iter().map(|s| OsString::from(*s)).collect()
+    }
+
+    #[test]
+    #[serial]
+    fn filtered_candidates_cd_empty_excludes_flags() {
+        let mut cmd = Cli::command();
+        let result = filtered_candidates(&mut cmd, args(&["ofsht", "cd", ""]), 2, None)
+            .expect("filtered_candidates must succeed");
+        let values = values_of(&result);
+        assert!(values.iter().any(|v| v == "@"), "expected @ in {values:?}");
+        assert!(
+            !values.iter().any(|v| v == "--color"),
+            "--color must be filtered in {values:?}"
+        );
+        assert!(
+            !values.iter().any(|v| v == "--help"),
+            "--help must be filtered in {values:?}"
+        );
+        assert!(
+            !values.iter().any(|v| v == "--verbose"),
+            "--verbose must be filtered in {values:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn filtered_candidates_cd_dash_includes_flags() {
+        let mut cmd = Cli::command();
+        let result = filtered_candidates(&mut cmd, args(&["ofsht", "cd", "-"]), 2, None)
+            .expect("filtered_candidates must succeed");
+        let values = values_of(&result);
+        assert!(
+            values.iter().any(|v| v == "--color"),
+            "--color must appear when dash is typed in {values:?}"
+        );
+    }
+
+    #[test]
+    fn filtered_shell_names_and_matches() {
+        assert_eq!(FilteredBash.name(), "bash");
+        assert!(FilteredBash.is("bash"));
+        assert!(!FilteredBash.is("zsh"));
+
+        assert_eq!(FilteredZsh.name(), "zsh");
+        assert!(FilteredZsh.is("zsh"));
+        assert!(!FilteredZsh.is("bash"));
+
+        assert_eq!(FilteredFish.name(), "fish");
+        assert!(FilteredFish.is("fish"));
+        assert!(!FilteredFish.is("bash"));
+    }
+
+    #[test]
+    fn zsh_escape_value_doubles_backslash_and_escapes_colon() {
+        assert_eq!(escape_zsh_value("plain"), "plain");
+        assert_eq!(escape_zsh_value("a:b"), "a\\:b");
+        assert_eq!(escape_zsh_value("a\\b"), "a\\\\b");
+        assert_eq!(escape_zsh_value("a\\b:c"), "a\\\\b\\:c");
+    }
+
+    #[test]
+    fn zsh_escape_help_doubles_backslash_only() {
+        assert_eq!(escape_zsh_help("plain"), "plain");
+        assert_eq!(escape_zsh_help("a:b"), "a:b");
+        assert_eq!(escape_zsh_help("a\\b"), "a\\\\b");
+    }
+
+    #[test]
+    #[serial]
+    fn filtered_candidates_option_value_regression() {
+        // Option value completion path must not be affected by the filter — `--color` takes
+        // a ValueEnum with PossibleValues auto/always/never; none of them start with `-`.
+        let mut cmd = Cli::command();
+        let result = filtered_candidates(&mut cmd, args(&["ofsht", "--color", ""]), 2, None)
+            .expect("filtered_candidates must succeed");
+        let values = values_of(&result);
+        assert!(
+            values.iter().any(|v| v == "auto"),
+            "auto must be present in {values:?}"
+        );
+        assert!(
+            values.iter().any(|v| v == "always"),
+            "always must be present in {values:?}"
+        );
+        assert!(
+            values.iter().any(|v| v == "never"),
+            "never must be present in {values:?}"
+        );
+        assert!(
+            !values.iter().any(|v| v.starts_with("--")),
+            "no `--` prefixed value must appear in option-value path: {values:?}"
+        );
+    }
+}

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -79,3 +79,113 @@ fn test_completions_invalid_shell() {
         "Command should fail for invalid shell"
     );
 }
+
+// ----- Flag-filter integration tests -----
+// These tests exercise the FilteredBash/Zsh/Fish adapters end-to-end by invoking
+// the binary directly via CARGO_BIN_EXE_ofsht (no cargo run recompilation).
+
+fn run_completion(shell: &str, index: Option<usize>, words: &[&str]) -> String {
+    let bin = env!("CARGO_BIN_EXE_ofsht");
+    let mut cmd = Command::new(bin);
+    cmd.env("COMPLETE", shell);
+    if let Some(i) = index {
+        cmd.env("_CLAP_COMPLETE_INDEX", i.to_string());
+    }
+    cmd.env("_CLAP_IFS", "\n");
+    cmd.arg("--");
+    for word in words {
+        cmd.arg(word);
+    }
+    let output = cmd
+        .output()
+        .unwrap_or_else(|e| panic!("failed to invoke {bin}: {e}"));
+    assert!(
+        output.status.success(),
+        "binary exited non-zero: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn test_cd_empty_word_excludes_flags() {
+    let stdout = run_completion("bash", Some(2), &["ofsht", "cd", ""]);
+    assert!(stdout.contains('@'), "expected @ in stdout: {stdout:?}");
+    for banned in ["--color", "--help", "--verbose", "-v", "-h"] {
+        assert!(
+            !stdout.contains(banned),
+            "{banned} must not appear in stdout: {stdout:?}"
+        );
+    }
+}
+
+#[test]
+fn test_cd_dash_includes_flags() {
+    let stdout = run_completion("bash", Some(2), &["ofsht", "cd", "-"]);
+    assert!(
+        stdout.contains("--color"),
+        "--color must appear when dash typed: {stdout:?}"
+    );
+}
+
+#[test]
+fn test_toplevel_empty_word_excludes_flags() {
+    let stdout = run_completion("bash", Some(1), &["ofsht", ""]);
+    for expected in ["add", "cd", "rm"] {
+        assert!(
+            stdout.contains(expected),
+            "{expected} must appear in top-level completion: {stdout:?}"
+        );
+    }
+    for banned in ["--color", "--help", "--version"] {
+        assert!(
+            !stdout.contains(banned),
+            "{banned} must not appear in top-level completion with empty current word: {stdout:?}"
+        );
+    }
+}
+
+#[test]
+fn test_option_value_completion_intact() {
+    let stdout = run_completion("bash", Some(2), &["ofsht", "--color", ""]);
+    for expected in ["auto", "always", "never"] {
+        assert!(
+            stdout.contains(expected),
+            "{expected} must appear in --color value completion: {stdout:?}"
+        );
+    }
+    for token in stdout.split_whitespace() {
+        assert!(
+            !token.starts_with("--"),
+            "unexpected flag-like token {token:?} in option-value completion: {stdout:?}"
+        );
+    }
+}
+
+#[test]
+fn test_zsh_empty_word_excludes_flags() {
+    let stdout = run_completion("zsh", Some(2), &["ofsht", "cd", ""]);
+    assert!(stdout.contains('@'), "expected @ in zsh stdout: {stdout:?}");
+    for banned in ["--color", "--help", "--verbose"] {
+        assert!(
+            !stdout.contains(banned),
+            "{banned} must not appear in zsh output: {stdout:?}"
+        );
+    }
+}
+
+#[test]
+fn test_fish_empty_word_excludes_flags() {
+    // Fish uses args.len() - 1 as index; _CLAP_COMPLETE_INDEX is ignored.
+    let stdout = run_completion("fish", None, &["ofsht", "cd", ""]);
+    assert!(
+        stdout.contains('@'),
+        "expected @ in fish stdout: {stdout:?}"
+    );
+    for line in stdout.lines() {
+        assert!(
+            !line.starts_with("--"),
+            "fish output line must not start with --: {line:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Tab completion for `ofsht cd`/`rm`/`add` leaked global flags (`--color`, `--verbose`, `--help`) into the positional-candidate slot, cluttering the suggestion list alongside branch/worktree names (and `@`). This PR adds a post-filter layer around clap_complete's shell adapters (Bash/Zsh/Fish) that drops flag candidates whenever the current word does not start with `-`, so flags only appear once the user explicitly types a dash.

### Before / After

```
# Before: flags leaked into positional context
❯ ofsht cd <TAB>
--color    -- When to use colored output
--help     -- Print help (see more with '--help')
--verbose  -- Show verbose output (e.g., full hook command output)
@

# After: positional candidates only; flags appear when dash is typed
❯ ofsht cd <TAB>
@

❯ ofsht cd -<TAB>
--color    -- When to use colored output
-v         -- --verbose
-h         -- --help
```

### Implementation

- New `src/shell_completion.rs` module exposes `filter_flag_candidates` (pure predicate + filter) and `filtered_candidates` helper, plus `FilteredBash`/`FilteredZsh`/`FilteredFish` impls of `clap_complete::env::EnvCompleter`.
- `write_registration` delegates to the built-ins unchanged (shell wiring scripts remain bit-for-bit compatible).
- `write_complete` post-filters `engine::complete`'s output while preserving each shell's byte-for-byte output format: Zsh keeps `value:help` with `_CLAP_IFS` plus `escape_value`/`escape_help`, Fish keeps `value\thelp\n` per record.
- `src/main.rs` wires the adapters via `CompleteEnv::with_factory(Cli::command).shells(Shells(&[&FilteredBash, &FilteredZsh, &FilteredFish])).complete()`.
- README Shell Completion section is updated to describe the new behavior.

### Scope

- In scope: Bash / Zsh / Fish (the officially supported shells). All subcommand positions (`cd` / `rm` / `add` start-point / top-level subcommand selection) plus option-value completion (`--color auto|always|never`).
- Out of scope (unchanged): AOT completion path in `commands/completion.rs`; Elvish / Powershell adapters; `ArgValueCompleter` internals.

### Known limitation

If a worktree directory literally starts with `-` (e.g., created via `git worktree add ./-foo feature`), it is filtered out when the current word is empty and only appears once the user types `-`. This is a pathological case — Git branch naming conventions forbid `-` as a leading character — and tag-based filtering was judged too costly to add for this edge. Documented in the plan's Risks.

### Tests

- 10 unit tests in `src/shell_completion.rs`: filter boundary cases, end-to-end `filtered_candidates` against the real `Cli::command()` tree (including `--color` value regression), Zsh escape helpers, adapter name/is.
- 6 integration tests in `tests/completions.rs` invoke the binary via `CARGO_BIN_EXE_ofsht` and verify Bash/Zsh/Fish behavior for empty / dash / top-level / option-value paths.
- 5 pre-existing smoke tests preserved unchanged.
- `just check` (fmt-ci + clippy-ci + test-ci) green: 513 tests pass across 11 suites.

## Test plan

- [x] `just check` passes locally (fmt + clippy strict + all tests)
- [x] `cargo test --test completions -- --test-threads=1` — 11/11 pass (6 new + 5 regression)
- [x] Empirical: `COMPLETE=bash _CLAP_COMPLETE_INDEX=2 ./target/debug/ofsht -- ofsht cd ""` → `@` only
- [x] Empirical: `COMPLETE=bash _CLAP_COMPLETE_INDEX=2 ./target/debug/ofsht -- ofsht cd "-"` → flags listed
- [x] Empirical: `COMPLETE=bash _CLAP_COMPLETE_INDEX=2 ./target/debug/ofsht -- ofsht --color ""` → `auto`/`always`/`never`, no `--` tokens
- [ ] Interactive verification in real shells (bash/zsh/fish) — reviewer to confirm

## References

- n/a
