### PR TITLE
feat: read positional arguments from stdin when piped

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -60,6 +60,13 @@ cargo run -- sync
 cargo run -- sync --link
 cargo run -- sync --run --copy
 
+# Test stdin input (auto-detected when piped; CLI arg always wins)
+echo feature-branch | cargo run -- add
+echo feature-branch | cargo run -- create
+echo feature-branch | cargo run -- cd
+printf 'feature-a\nfeature-b\n' | cargo run -- rm
+cargo run -- add < /dev/null  # errors with "branch name required"
+
 # Use release binary
 ./target/release/ofsht add feature-branch
 ```
@@ -100,6 +107,7 @@ src/
 ├── domain/           # Domain models and logic
 │   └── worktree.rs   # Worktree entry parsing and formatting
 ├── hooks.rs          # Hook execution engine (run/copy/link)
+├── stdin.rs          # Stdin input helpers (TTY-aware) for piped argument resolution
 ├── integrations/     # External tool integrations
 │   ├── fzf/          # Interactive selection
 │   ├── gh/           # GitHub CLI integration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,7 @@ src/
 ├── color.rs             # Color output utilities
 ├── hooks.rs             # Hook execution engine (run/copy/link)
 ├── service.rs           # Service layer orchestrating git, hooks, and integrations
+├── stdin.rs             # Stdin input helpers (TTY-aware) for piped argument resolution
 ├── commands/
 │   ├── common.rs        # Shared utilities for command handlers
 │   ├── open.rs          # Open all worktrees in tmux

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A command-line tool for managing Git worktrees with automation features.
 - [Quick Start](#quick-start)
 - [Usage](#usage)
   - [Basic Operations](#basic-operations)
+  - [Stdin Input](#stdin-input)
   - [Sync Hook Operations](#sync-hook-operations)
   - [GitHub Integration](#github-integration)
   - [Shell Integration](#shell-integration)
@@ -44,6 +45,7 @@ A command-line tool for managing Git worktrees with automation features.
 - Navigate to worktrees by branch name
 - Remove worktrees with automatic branch cleanup
 - Interactive worktree selection with fzf integration
+- Read branch / target names from stdin when piped (auto-detected for `add`, `create`, `cd`, `rm`)
 
 ⚙️ **Automation & Hooks**
 - Run commands after worktree creation (e.g., `npm install`)
@@ -238,6 +240,31 @@ ofsht rm feature-deleted
 
 > [!NOTE]
 > `ofsht rm` can remove worktrees even if their directories have been manually deleted. Git marks such worktrees as "prunable" (still registered in Git but directory missing), and `ofsht` handles them gracefully by cleaning up the Git registration.
+
+### Stdin Input
+
+When stdin is piped or redirected, `ofsht` automatically reads positional arguments from it. CLI arguments always take priority; stdin is used only when the corresponding argument is omitted.
+
+```bash
+# add / create read the first non-empty line as the branch name
+echo my-feature | ofsht add
+echo bugfix-1 | ofsht create
+
+# cd reads the first non-empty line as the worktree name
+echo feature-awesome | ofsht cd
+
+# rm reads each non-empty line as a target (xargs-style)
+printf 'feature-a\nfeature-b\n' | ofsht rm
+
+# CLI arguments always win — stdin is ignored when an argument is present
+echo ignored-name | ofsht add explicit-name   # creates "explicit-name"
+```
+
+> [!NOTE]
+> Stdin is read only when the input is **not a TTY** (i.e. piped or redirected). On an interactive terminal with no arguments, `cd` / `rm` continue to launch fzf as before, and `add` / `create` exit with `branch name required`.
+
+> [!NOTE]
+> For `add` / `create` (single-argument), only the first non-empty line is used. For `rm` (multi-argument), every non-empty line becomes a target.
 
 ### Shell Integration
 
@@ -618,6 +645,21 @@ ofsht rm feature-new-api          # Hooks run cleanup commands
 
 # Or clean up from within the worktree
 ofsht rm .                        # Automatically returns to main repo
+```
+
+### Piping with Other Tools
+
+```bash
+# Bulk-remove every merged feature branch's worktree
+git branch --merged main | grep -v '^\*\|main$' | ofsht rm
+
+# Spin up a worktree for each open PR you own
+gh pr list --author @me --json headRefName -q '.[].headRefName' | while read branch; do
+    echo "$branch" | ofsht add
+done
+
+# Drive cd from another tool's selection (default `ls` emits one branch name per line)
+ofsht ls | fzf | ofsht cd
 ```
 
 ### Restoring tmux Workspace After Restart

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -655,6 +655,85 @@ ofsht open
 # "No worktrees to open (all worktrees are already in the current session)."
 ```
 
+## Stdin Input Verification
+
+`ofsht` reads positional arguments from stdin when stdin is piped or redirected (auto-detected via TTY check). CLI arguments always take priority. Verify each command from a fresh test repository.
+
+### 1. Setup
+
+```bash
+cd /tmp
+rm -rf demo-stdin
+mkdir demo-stdin
+cd demo-stdin
+git init
+git commit --allow-empty -m "Initial commit"
+```
+
+### 2. `add` Reads Branch From Stdin
+
+```bash
+echo "stdin-feat" | ofsht add
+
+# Expected:
+# - Worktree created at ../demo-stdin-worktrees/stdin-feat
+# - "Added stdin-feat" on stderr
+ls -la ../demo-stdin-worktrees/stdin-feat
+```
+
+### 3. `cd` Reads Name From Stdin
+
+```bash
+echo "stdin-feat" | ofsht cd
+
+# Expected:
+# - Absolute path of stdin-feat worktree printed to stdout
+```
+
+### 4. `rm` Reads Multiple Targets From Stdin
+
+```bash
+ofsht add stdin-rm-a
+ofsht add stdin-rm-b
+
+printf 'stdin-rm-a\nstdin-rm-b\n' | ofsht rm
+
+# Expected:
+# - Both worktrees removed
+# - "Removed stdin-rm-a" and "Removed stdin-rm-b" on stderr
+ls ../demo-stdin-worktrees/  # neither directory should remain
+```
+
+### 5. CLI Argument Wins Over Stdin
+
+```bash
+echo "stdin-name" | ofsht add explicit-name
+
+# Expected:
+# - Worktree "explicit-name" created (stdin "stdin-name" ignored)
+ls -la ../demo-stdin-worktrees/explicit-name
+[ ! -d ../demo-stdin-worktrees/stdin-name ] && echo "OK: stdin-name not created"
+```
+
+### 6. Empty Stdin Errors For `add` / `create`
+
+```bash
+ofsht add < /dev/null
+
+# Expected:
+# - Non-zero exit
+# - Error: "branch name required (provide as argument or via stdin)"
+```
+
+### 7. Interactive TTY Falls Back To Existing Behavior
+
+```bash
+# In an interactive shell (no piping):
+ofsht cd      # launches fzf as before (if fzf is installed and enabled)
+ofsht rm      # launches fzf as before
+ofsht add     # exits with "branch name required"
+```
+
 ## Summary
 
 This document verified the following features:
@@ -665,6 +744,7 @@ This document verified the following features:
 - ✅ Sync command (sync hook operations to existing worktrees)
 - ✅ Open command (open all worktrees in tmux)
 - ✅ zoxide integration
+- ✅ Stdin input (auto-detected when piped; CLI arg priority; per-command line semantics)
 - ✅ Path template customization
 - ✅ Local/global configuration
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,8 +29,8 @@ pub struct Cli {
 pub enum Commands {
     /// Create a new worktree with a branch
     Add {
-        /// Branch name for the new worktree
-        branch: String,
+        /// Branch name for the new worktree (read from stdin when omitted and stdin is piped)
+        branch: Option<String>,
         /// Start point (branch, tag, or commit) for the new branch.
         /// Defaults to HEAD if not specified.
         #[arg(add = ArgValueCompleter::new(list_git_refs))]
@@ -44,8 +44,8 @@ pub enum Commands {
     },
     /// Create a new worktree without navigation
     Create {
-        /// Branch name for the new worktree
-        branch: String,
+        /// Branch name for the new worktree (read from stdin when omitted and stdin is piped)
+        branch: Option<String>,
         /// Start point (branch, tag, or commit) for the new branch.
         /// Defaults to HEAD if not specified.
         #[arg(add = ArgValueCompleter::new(list_git_refs))]

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -181,12 +181,21 @@ const fn should_use_tmux(
 /// - Zoxide registration fails
 #[allow(clippy::too_many_lines, clippy::missing_panics_doc)]
 pub fn cmd_new(
-    branch: &str,
+    branch: Option<&str>,
     start_point: Option<&str>,
     tmux: bool,
     no_tmux: bool,
     color_mode: color::ColorMode,
 ) -> Result<()> {
+    // Resolve branch: CLI arg > stdin (when piped) > error
+    let branch_owned = match branch {
+        Some(b) => b.to_string(),
+        None => crate::stdin::try_read_stdin_first()?.ok_or_else(|| {
+            anyhow::anyhow!("branch name required (provide as argument or via stdin)")
+        })?,
+    };
+    let branch = branch_owned.as_str();
+
     // Get main repository root
     let repo_root = get_main_repo_root()?;
 

--- a/src/commands/cd.rs
+++ b/src/commands/cd.rs
@@ -31,8 +31,13 @@ pub fn cmd_goto(name: Option<&str>, _color_mode: crate::color::ColorMode) -> Res
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // If no name provided, use fzf for interactive selection
-    let Some(name) = name else {
+    // Resolve name: CLI arg > stdin (when piped) > fzf
+    let resolved_name: Option<String> = match name {
+        Some(n) => Some(n.to_string()),
+        None => crate::stdin::try_read_stdin_first()?,
+    };
+
+    let Some(name) = resolved_name else {
         let repo_root = get_main_repo_root()?;
         let config = config::Config::load_from_repo_root(&repo_root)?;
 
@@ -63,6 +68,7 @@ pub fn cmd_goto(name: Option<&str>, _color_mode: crate::color::ColorMode) -> Res
         println!("{}", normalize_absolute_path(&PathBuf::from(&selected[0])));
         return Ok(());
     };
+    let name = name.as_str();
 
     // Special handling for "@" (main worktree)
     if name == "@" {

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -21,10 +21,19 @@ use crate::integrations;
 /// - Zoxide registration fails
 #[allow(clippy::missing_panics_doc)]
 pub fn cmd_create(
-    branch: &str,
+    branch: Option<&str>,
     start_point: Option<&str>,
     color_mode: color::ColorMode,
 ) -> Result<()> {
+    // Resolve branch: CLI arg > stdin (when piped) > error
+    let branch_owned = match branch {
+        Some(b) => b.to_string(),
+        None => crate::stdin::try_read_stdin_first()?.ok_or_else(|| {
+            anyhow::anyhow!("branch name required (provide as argument or via stdin)")
+        })?,
+    };
+    let branch = branch_owned.as_str();
+
     // Get main repository root
     let repo_root = get_main_repo_root()?;
 

--- a/src/commands/rm.rs
+++ b/src/commands/rm.rs
@@ -139,37 +139,43 @@ pub fn cmd_rm_many(targets: &[String], color_mode: color::ColorMode) -> Result<(
 
     let list_stdout = String::from_utf8_lossy(&list_output.stdout);
 
-    // If no targets provided, use fzf for interactive multi-selection
+    // Resolve targets: CLI args > stdin (when piped) > fzf
     let targets: Vec<String> = if targets.is_empty() {
-        if !config.integrations.fzf.enabled {
-            anyhow::bail!("Provide at least one target or enable fzf in config");
+        let stdin_targets = crate::stdin::try_read_stdin_lines()?;
+        if stdin_targets.is_empty() {
+            if !config.integrations.fzf.enabled {
+                anyhow::bail!("Provide at least one target or enable fzf in config");
+            }
+
+            if !integrations::fzf::is_fzf_available() {
+                anyhow::bail!("fzf is not installed. Install it or provide at least one target");
+            }
+
+            // Build items for fzf
+            let items = integrations::fzf::build_worktree_items(&list_stdout);
+
+            if items.is_empty() {
+                anyhow::bail!("No worktrees found");
+            }
+
+            // Use fzf to select (multi-select enabled)
+            let picker =
+                integrations::fzf::RealFzfPicker::new(config.integrations.fzf.options.clone());
+            let selected = picker.pick(&items, true)?;
+
+            if selected.is_empty() {
+                // User pressed Esc or no selection
+                return Ok(());
+            }
+
+            // selected contains paths, convert them to branch names or paths as targets
+            selected
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect()
+        } else {
+            stdin_targets
         }
-
-        if !integrations::fzf::is_fzf_available() {
-            anyhow::bail!("fzf is not installed. Install it or provide at least one target");
-        }
-
-        // Build items for fzf
-        let items = integrations::fzf::build_worktree_items(&list_stdout);
-
-        if items.is_empty() {
-            anyhow::bail!("No worktrees found");
-        }
-
-        // Use fzf to select (multi-select enabled)
-        let picker = integrations::fzf::RealFzfPicker::new(config.integrations.fzf.options.clone());
-        let selected = picker.pick(&items, true)?;
-
-        if selected.is_empty() {
-            // User pressed Esc or no selection
-            return Ok(());
-        }
-
-        // selected contains paths, convert them to branch names or paths as targets
-        selected
-            .iter()
-            .map(std::string::ToString::to_string)
-            .collect()
     } else {
         targets.to_vec()
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,20 @@
-// Export modules for testing
+// Internal-only library surface. Modules are exposed solely so that the binary's
+// own integration tests and doctests can reach them; this crate is published
+// primarily as a CLI binary, not as a stable library API. Signatures here may
+// change in any release without a major version bump.
 #![allow(clippy::literal_string_with_formatting_args)]
 pub mod cli;
 pub mod color;
 pub mod config;
 pub mod hooks;
 pub mod service;
+pub mod stdin;
 
 // Integration modules
 pub mod integrations;
 
-// Command modules
+// Command modules — internal handlers, not a stable API surface.
+#[doc(hidden)]
 pub mod commands;
 
 // Domain modules

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod hooks;
 mod integrations;
 mod service;
 mod shell_completion;
+mod stdin;
 
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
@@ -43,11 +44,17 @@ fn main() -> Result<()> {
             start_point,
             tmux,
             no_tmux,
-        } => commands::add::cmd_new(&branch, start_point.as_deref(), tmux, no_tmux, color_mode),
+        } => commands::add::cmd_new(
+            branch.as_deref(),
+            start_point.as_deref(),
+            tmux,
+            no_tmux,
+            color_mode,
+        ),
         Commands::Create {
             branch,
             start_point,
-        } => commands::create::cmd_create(&branch, start_point.as_deref(), color_mode),
+        } => commands::create::cmd_create(branch.as_deref(), start_point.as_deref(), color_mode),
         Commands::Ls { show_path } => commands::list::cmd_list(show_path, color_mode),
         Commands::Rm { targets } => commands::rm::cmd_rm_many(&targets, color_mode),
         Commands::Cd { name } => commands::cd::cmd_goto(name.as_deref(), color_mode),

--- a/src/stdin.rs
+++ b/src/stdin.rs
@@ -1,0 +1,162 @@
+//! Stdin input helpers
+//!
+//! When stdin is not a TTY (i.e. piped or redirected), commands can read positional
+//! values from stdin instead of CLI arguments. The TTY check ensures interactive
+//! sessions keep their existing behavior (errors / fzf fallbacks).
+
+use anyhow::{Context, Result};
+use std::io::{self, BufRead, BufReader, IsTerminal, Read};
+
+/// Read the first non-empty trimmed line from stdin when it is piped/redirected.
+///
+/// Returns `Ok(None)` when stdin is a TTY or contains no non-empty lines.
+///
+/// # Errors
+/// Returns an error if reading from stdin fails for an I/O reason other than EOF.
+pub fn try_read_stdin_first() -> Result<Option<String>> {
+    let stdin = io::stdin();
+    if stdin.is_terminal() {
+        return Ok(None);
+    }
+    read_first_from(stdin.lock())
+}
+
+/// Read all non-empty trimmed lines from stdin when it is piped/redirected.
+///
+/// Returns `Ok(vec![])` when stdin is a TTY or contains no non-empty lines.
+///
+/// # Errors
+/// Returns an error if reading from stdin fails for an I/O reason other than EOF.
+pub fn try_read_stdin_lines() -> Result<Vec<String>> {
+    let stdin = io::stdin();
+    if stdin.is_terminal() {
+        return Ok(vec![]);
+    }
+    read_lines_from(stdin.lock())
+}
+
+fn read_first_from<R: Read>(reader: R) -> Result<Option<String>> {
+    // Read line by line and short-circuit on the first non-empty trimmed line.
+    // This avoids blocking on producers that keep the pipe open after writing
+    // a single line (e.g., `tail -f`).
+    let buf = BufReader::new(reader);
+    for line in buf.lines() {
+        let line = line.context("Failed to read from stdin")?;
+        let trimmed = line.trim();
+        if !trimmed.is_empty() {
+            return Ok(Some(trimmed.to_string()));
+        }
+    }
+    Ok(None)
+}
+
+fn read_lines_from<R: Read>(reader: R) -> Result<Vec<String>> {
+    // Multi-target callers (e.g., `rm`) need every non-empty line, so we drain
+    // the pipe until EOF.
+    let buf = BufReader::new(reader);
+    let mut out = Vec::new();
+    for line in buf.lines() {
+        let line = line.context("Failed to read from stdin")?;
+        let trimmed = line.trim();
+        if !trimmed.is_empty() {
+            out.push(trimmed.to_string());
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn read_first_from_single_line() {
+        let result = read_first_from(Cursor::new(b"feat\n")).unwrap();
+        assert_eq!(result, Some("feat".to_string()));
+    }
+
+    #[test]
+    fn read_first_from_multiline_returns_first() {
+        let result = read_first_from(Cursor::new(b"a\nb\nc\n")).unwrap();
+        assert_eq!(result, Some("a".to_string()));
+    }
+
+    #[test]
+    fn read_first_from_empty() {
+        let result = read_first_from(Cursor::new(b"")).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn read_first_from_blank_only() {
+        let result = read_first_from(Cursor::new(b"\n\n  \n")).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn read_first_from_trims_whitespace() {
+        let result = read_first_from(Cursor::new(b"  feat  \n")).unwrap();
+        assert_eq!(result, Some("feat".to_string()));
+    }
+
+    #[test]
+    fn read_first_from_skips_leading_blank_lines() {
+        let result = read_first_from(Cursor::new(b"\n\nfeat\nother\n")).unwrap();
+        assert_eq!(result, Some("feat".to_string()));
+    }
+
+    #[test]
+    fn read_first_from_short_circuits_before_eof() {
+        // Custom reader that yields a non-empty line and then panics if read
+        // again, proving the helper does not wait for EOF.
+        struct OneLineThenPanic {
+            yielded: bool,
+        }
+        impl std::io::Read for OneLineThenPanic {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                assert!(
+                    !self.yielded,
+                    "read_first_from must not read past the first non-empty line"
+                );
+                self.yielded = true;
+                let payload = b"feat\n";
+                buf[..payload.len()].copy_from_slice(payload);
+                Ok(payload.len())
+            }
+        }
+
+        let result = read_first_from(OneLineThenPanic { yielded: false }).unwrap();
+        assert_eq!(result, Some("feat".to_string()));
+    }
+
+    #[test]
+    fn read_lines_from_multiline() {
+        let result = read_lines_from(Cursor::new(b"a\nb\nc\n")).unwrap();
+        assert_eq!(result, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn read_lines_from_filters_blank_lines() {
+        let result = read_lines_from(Cursor::new(b"a\n\nb\n\n  \nc\n")).unwrap();
+        assert_eq!(result, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn read_lines_from_empty() {
+        let result = read_lines_from(Cursor::new(b"")).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn read_lines_from_blank_only() {
+        let result = read_lines_from(Cursor::new(b"\n\n  \n")).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn read_lines_from_trims_whitespace() {
+        let result = read_lines_from(Cursor::new(b"  a  \n  b  \n")).unwrap();
+        assert_eq!(result, vec!["a", "b"]);
+    }
+}

--- a/tests/stdin_input.rs
+++ b/tests/stdin_input.rs
@@ -1,0 +1,164 @@
+#![allow(deprecated)]
+
+use assert_fs::prelude::*;
+use std::process::{Command, Stdio};
+
+/// Initialize a git repository with a single empty commit.
+fn init_repo(repo_dir: &assert_fs::fixture::ChildPath) {
+    repo_dir.create_dir_all().unwrap();
+    Command::new("git")
+        .args(["init"])
+        .current_dir(repo_dir.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(repo_dir.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(repo_dir.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "--allow-empty", "-m", "Initial commit"])
+        .current_dir(repo_dir.path())
+        .output()
+        .unwrap();
+}
+
+#[test]
+fn add_reads_branch_from_piped_stdin() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let repo_dir = temp.child("test-repo");
+    init_repo(&repo_dir);
+
+    let mut cmd = assert_cmd::Command::cargo_bin("ofsht").unwrap();
+    cmd.arg("add")
+        .write_stdin("feat-from-stdin\n")
+        .current_dir(repo_dir.path())
+        .assert()
+        .success();
+
+    let worktree_path = temp.path().join("test-repo-worktrees/feat-from-stdin");
+    assert!(
+        worktree_path.exists(),
+        "expected worktree at {worktree_path:?}"
+    );
+}
+
+#[test]
+fn cd_reads_name_from_piped_stdin() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let repo_dir = temp.child("test-repo");
+    init_repo(&repo_dir);
+
+    // Pre-create a worktree to navigate to
+    assert_cmd::Command::cargo_bin("ofsht")
+        .unwrap()
+        .args(["add", "feat-cd"])
+        .current_dir(repo_dir.path())
+        .assert()
+        .success();
+
+    let mut cmd = assert_cmd::Command::cargo_bin("ofsht").unwrap();
+    let output = cmd
+        .arg("cd")
+        .write_stdin("feat-cd\n")
+        .current_dir(repo_dir.path())
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+    assert!(
+        stdout.contains("test-repo-worktrees/feat-cd"),
+        "expected stdout to contain worktree path, got: {stdout}"
+    );
+}
+
+#[test]
+fn rm_reads_multiple_targets_from_piped_stdin() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let repo_dir = temp.child("test-repo");
+    init_repo(&repo_dir);
+
+    for name in ["feat-rm-a", "feat-rm-b"] {
+        assert_cmd::Command::cargo_bin("ofsht")
+            .unwrap()
+            .args(["add", name])
+            .current_dir(repo_dir.path())
+            .assert()
+            .success();
+    }
+
+    let worktree_a = temp.path().join("test-repo-worktrees/feat-rm-a");
+    let worktree_b = temp.path().join("test-repo-worktrees/feat-rm-b");
+    assert!(worktree_a.exists());
+    assert!(worktree_b.exists());
+
+    assert_cmd::Command::cargo_bin("ofsht")
+        .unwrap()
+        .arg("rm")
+        .write_stdin("feat-rm-a\nfeat-rm-b\n")
+        .current_dir(repo_dir.path())
+        .assert()
+        .success();
+
+    assert!(!worktree_a.exists());
+    assert!(!worktree_b.exists());
+}
+
+#[test]
+fn add_cli_arg_takes_priority_over_stdin() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let repo_dir = temp.child("test-repo");
+    init_repo(&repo_dir);
+
+    // CLI arg explicit-name should win; stdin "stdin-name" should be ignored.
+    assert_cmd::Command::cargo_bin("ofsht")
+        .unwrap()
+        .args(["add", "explicit-name"])
+        .write_stdin("stdin-name\n")
+        .current_dir(repo_dir.path())
+        .assert()
+        .success();
+
+    let cli_path = temp.path().join("test-repo-worktrees/explicit-name");
+    let stdin_path = temp.path().join("test-repo-worktrees/stdin-name");
+    assert!(cli_path.exists(), "CLI-arg worktree should exist");
+    assert!(
+        !stdin_path.exists(),
+        "stdin-arg worktree must NOT exist when CLI arg is present"
+    );
+}
+
+#[test]
+fn add_with_closed_stdin_errors_with_branch_required_message() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let repo_dir = temp.child("test-repo");
+    init_repo(&repo_dir);
+
+    // Use std::process::Command directly with /dev/null on stdin to ensure
+    // is_terminal() returns false but no input is available.
+    let bin = assert_cmd::cargo::cargo_bin("ofsht");
+    let output = Command::new(bin)
+        .arg("add")
+        .current_dir(repo_dir.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit, got: {:?}",
+        output.status
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("branch name required"),
+        "expected stderr to contain 'branch name required', got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add stdin input support for `add`, `create`, `cd`, and `rm`. When stdin is piped or redirected (auto-detected via `IsTerminal`), each command reads its positional argument(s) from stdin. CLI arguments always take priority; interactive TTY behavior is preserved (`add` / `create` error with `branch name required`; `cd` / `rm` fall back to fzf).
- New `src/stdin.rs` exposes `try_read_stdin_first` (short-circuits on the first non-empty line so long-lived producers like `tail -f` do not block) and `try_read_stdin_lines` (drains the pipe for xargs-style multi-target `rm`).
- Resolution priority per command:
  - `add` / `create`: CLI arg > first non-empty stdin line > error
  - `cd`: CLI arg > first non-empty stdin line > fzf
  - `rm`: CLI args > all non-empty stdin lines > fzf
- Documentation updated across `README.md`, `CONTRIBUTING.md`, `docs/TEST.md`, and `.claude/CLAUDE.md`. The library surface is internal-only (`commands` is `#[doc(hidden)]`); the published binary is the stable artifact.

## Test plan

- [x] `cargo test` — 552 passed (13 suites)
- [x] `just check` — fmt, clippy (strict pedantic + nursery), tests all green
- [x] Manual smoke: piped stdin for `add` / `cd` / `rm`, CLI-arg priority over stdin, empty stdin error message
- [x] Regression test for `read_first_from` short-circuit (panics if read past first non-empty line)

## References

- n/a
