### PR TITLE
refactor: unify worktree porcelain parsers into WorktreeList

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -248,21 +248,26 @@ pub fn list_git_worktrees(current: &OsStr) -> Vec<CompletionCandidate> {
         candidates_set.insert("@".to_string());
     }
 
-    // Add branch names (existing behavior)
-    for branch in parse_worktree_list(&stdout) {
-        candidates_set.insert(branch);
+    // Parse the porcelain output once via the unified WorktreeList type.
+    let list = crate::domain::worktree::WorktreeList::parse(&stdout, None);
+
+    // Add branch names from non-main worktrees (excludes main automatically).
+    // This naturally fixes a latent inconsistency in the legacy parser
+    // (`worktree_index > 0` vs `> 1`) where main could leak into completion candidates
+    // when entry separators were missing in malformed porcelain.
+    for entry in list.non_main() {
+        if let Some(branch) = &entry.branch {
+            candidates_set.insert(branch.clone());
+        }
     }
 
     // Try to add relative paths (new behavior)
     if let Ok(repo_root) = crate::commands::common::get_main_repo_root() {
         if crate::config::Config::load_from_repo_root(&repo_root).is_ok() {
-            // Parse worktrees to get paths
-            let entries = crate::domain::worktree::parse_worktree_entries(&stdout, None);
-
-            // Collect all non-main worktree paths (skip index 0 which is main)
-            let worktree_paths: Vec<PathBuf> = entries
+            // Collect all non-main worktree paths
+            let worktree_paths: Vec<PathBuf> = list
+                .non_main()
                 .iter()
-                .skip(1)
                 .map(|entry| PathBuf::from(&entry.path))
                 .collect();
 
@@ -271,7 +276,7 @@ pub fn list_git_worktrees(current: &OsStr) -> Vec<CompletionCandidate> {
                 crate::domain::worktree::calculate_worktree_root_from_paths(&worktree_paths)
             {
                 // Add relative paths for all non-main worktrees
-                for entry in entries.iter().skip(1) {
+                for entry in list.non_main() {
                     let worktree_path = PathBuf::from(&entry.path);
                     if let Some(rel_path) = crate::domain::worktree::calculate_relative_path(
                         &worktree_path,
@@ -292,52 +297,10 @@ pub fn list_git_worktrees(current: &OsStr) -> Vec<CompletionCandidate> {
         .collect()
 }
 
-/// Parse git worktree list --porcelain output and extract branch names
-/// Excludes the main worktree (first worktree in the list)
-#[must_use]
-pub fn parse_worktree_list(output: &str) -> Vec<String> {
-    let mut branches = Vec::new();
-    let mut worktree_index = 0;
-    let mut current_branch: Option<String> = None;
-
-    for line in output.lines() {
-        if line.starts_with("worktree ") {
-            // Save previous worktree's branch (skip first/main worktree at index 0)
-            if let Some(branch) = current_branch.take() {
-                if worktree_index > 0 {
-                    branches.push(branch);
-                }
-            }
-            worktree_index += 1;
-        } else if line.starts_with("branch ") {
-            if let Some(branch_ref) = line.strip_prefix("branch ") {
-                // Strip refs/heads/ prefix
-                let branch = branch_ref.strip_prefix("refs/heads/").unwrap_or(branch_ref);
-                current_branch = Some(branch.to_string());
-            }
-        } else if line.is_empty() {
-            // End of worktree entry
-            if let Some(branch) = current_branch.take() {
-                if worktree_index > 1 {
-                    branches.push(branch);
-                }
-            }
-        }
-    }
-
-    // Handle last worktree if exists
-    if let Some(branch) = current_branch {
-        if worktree_index > 1 {
-            branches.push(branch);
-        }
-    }
-
-    branches
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::worktree::WorktreeList;
 
     #[test]
     fn verify_cli() {
@@ -400,8 +363,18 @@ mod tests {
         }
     }
 
+    /// Helper: extract branch names from non-main worktrees, mirroring the
+    /// completion path inside `list_git_worktrees`.
+    fn worktree_list_branches(output: &str) -> Vec<String> {
+        WorktreeList::parse(output, None)
+            .non_main()
+            .iter()
+            .filter_map(|e| e.branch.clone())
+            .collect()
+    }
+
     #[test]
-    fn test_parse_worktree_list_excludes_main() {
+    fn test_worktree_list_branches_excludes_main() {
         let output = "worktree /path/to/main
 branch refs/heads/main
 
@@ -409,12 +382,12 @@ worktree /path/to/feature
 branch refs/heads/feature
 
 ";
-        let result = parse_worktree_list(output);
+        let result = worktree_list_branches(output);
         assert_eq!(result, vec!["feature"]);
     }
 
     #[test]
-    fn test_parse_worktree_list_multiple_worktrees() {
+    fn test_worktree_list_branches_multiple_worktrees() {
         let output = "worktree /path/to/main
 branch refs/heads/main
 
@@ -425,15 +398,33 @@ worktree /path/to/feature-b
 branch refs/heads/feature-b
 
 ";
-        let result = parse_worktree_list(output);
+        let result = worktree_list_branches(output);
         assert_eq!(result, vec!["feature-a", "feature-b"]);
     }
 
     #[test]
-    fn test_parse_worktree_list_empty() {
+    fn test_worktree_list_branches_empty() {
         let output = "";
-        let result = parse_worktree_list(output);
+        let result = worktree_list_branches(output);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_completion_excludes_main_branch_for_malformed_separator_missing() {
+        // Regression for a latent bug in the previous standalone branch-list parser
+        // (worktree-index threshold mismatch): when entry separators were missing
+        // the main branch leaked into completion candidates. WorktreeList::parse uses
+        // index-0-is-main semantics so the main branch must never appear here.
+        let output = "worktree /path/to/main\nbranch refs/heads/main\nworktree /path/to/feat\nbranch refs/heads/feat\n";
+        let result = worktree_list_branches(output);
+        assert!(
+            !result.contains(&"main".to_string()),
+            "main branch must not be in completion candidates even with missing entry separators: {result:?}"
+        );
+        assert!(
+            result.contains(&"feat".to_string()),
+            "non-main branch must still be present: {result:?}"
+        );
     }
 
     #[test]

--- a/src/commands/cd.rs
+++ b/src/commands/cd.rs
@@ -4,9 +4,9 @@ use anyhow::{Context, Result};
 use std::path::PathBuf;
 use std::process::Command;
 
-use crate::commands::common::{find_worktree_by_path, get_main_repo_root, parse_all_worktrees};
+use crate::commands::common::get_main_repo_root;
 use crate::config;
-use crate::domain::worktree::normalize_absolute_path;
+use crate::domain::worktree::{normalize_absolute_path, WorktreeList};
 use crate::integrations;
 use crate::integrations::fzf::FzfPicker;
 
@@ -70,10 +70,17 @@ pub fn cmd_goto(name: Option<&str>, _color_mode: crate::color::ColorMode) -> Res
     };
     let name = name.as_str();
 
+    // Parse the porcelain output once and reuse the WorktreeList for all 3
+    // resolution passes (`@`, branch name, relative path, absolute path).
+    let list = WorktreeList::parse(&stdout, None);
+
     // Special handling for "@" (main worktree)
     if name == "@" {
-        let (main_path, _) = parse_all_worktrees(&stdout);
-        println!("{}", normalize_absolute_path(&PathBuf::from(&main_path)));
+        let main_path = list
+            .main()
+            .map(|m| m.path.as_str())
+            .context("git worktree list returned no entries")?;
+        println!("{}", normalize_absolute_path(&PathBuf::from(main_path)));
         return Ok(());
     }
 
@@ -82,54 +89,25 @@ pub fn cmd_goto(name: Option<&str>, _color_mode: crate::color::ColorMode) -> Res
     let config = config::Config::load_from_repo_root(&repo_root).ok();
 
     // Priority 1: Try to find by branch name
-    let mut current_path: Option<&str> = None;
-    let mut found_path: Option<String> = None;
-
-    for line in stdout.lines() {
-        if let Some(path) = line.strip_prefix("worktree ") {
-            current_path = Some(path);
-        } else if let Some(branch_line) = line.strip_prefix("branch ") {
-            let branch = branch_line
-                .strip_prefix("refs/heads/")
-                .unwrap_or(branch_line);
-
-            // Check if this is the branch we're looking for
-            if branch == name {
-                if let Some(path) = current_path {
-                    found_path = Some(path.to_string());
-                    break;
-                }
-            }
-        } else if line.is_empty() {
-            current_path = None;
-        }
-    }
-
-    if let Some(path) = found_path {
-        println!("{}", normalize_absolute_path(&PathBuf::from(&path)));
+    if let Some(entry) = list.find_by_branch(name) {
+        println!("{}", normalize_absolute_path(&PathBuf::from(&entry.path)));
         return Ok(());
     }
 
     // Priority 2: Try to resolve as relative path (if config is available)
     if config.is_some() {
-        // Parse worktrees to get all non-main worktree paths
-        let (_main_path, worktrees) = parse_all_worktrees(&stdout);
-
-        // Collect all non-main worktree paths
-        let worktree_paths: Vec<PathBuf> = worktrees
+        let worktree_paths: Vec<PathBuf> = list
+            .non_main()
             .iter()
-            .map(|(path, _)| PathBuf::from(path))
+            .map(|e| PathBuf::from(&e.path))
             .collect();
 
         if let Some(worktree_root) =
             crate::domain::worktree::calculate_worktree_root_from_paths(&worktree_paths)
         {
-            // Convert relative path to absolute path
             let abs_path = worktree_root.join(name);
-
-            // Try to find worktree by this absolute path
-            if let Some(path) = find_worktree_by_path(&stdout, &abs_path) {
-                println!("{}", normalize_absolute_path(&PathBuf::from(&path)));
+            if let Some(entry) = list.find_by_path(&abs_path) {
+                println!("{}", normalize_absolute_path(&PathBuf::from(&entry.path)));
                 return Ok(());
             }
         }
@@ -137,8 +115,8 @@ pub fn cmd_goto(name: Option<&str>, _color_mode: crate::color::ColorMode) -> Res
 
     // Priority 3: Try to resolve as absolute path (fallback)
     let input_path = PathBuf::from(name);
-    if let Some(path) = find_worktree_by_path(&stdout, &input_path) {
-        println!("{}", normalize_absolute_path(&PathBuf::from(&path)));
+    if let Some(entry) = list.find_by_path(&input_path) {
+        println!("{}", normalize_absolute_path(&PathBuf::from(&entry.path)));
         return Ok(());
     }
 

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -6,6 +6,8 @@ use anyhow::{Context, Result};
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
+use crate::domain::worktree::WorktreeList;
+
 /// Get the main repository root path
 ///
 /// # Errors
@@ -45,153 +47,6 @@ pub fn get_main_repo_root() -> Result<PathBuf> {
         .unwrap_or(abs_git_path);
 
     Ok(repo_root)
-}
-
-/// Find worktree path by branch name
-/// Returns None if branch not found or is main worktree
-pub fn find_worktree_by_branch(output: &str, branch_name: &str) -> Option<String> {
-    let mut current_path: Option<String> = None;
-    let mut worktree_index = 0;
-
-    for line in output.lines() {
-        if line.starts_with("worktree ") {
-            current_path = line.strip_prefix("worktree ").map(String::from);
-            worktree_index += 1;
-        } else if line.starts_with("branch ") {
-            if let Some(branch_ref) = line.strip_prefix("branch ") {
-                let branch = branch_ref.strip_prefix("refs/heads/").unwrap_or(branch_ref);
-
-                // Skip main worktree (index 1)
-                if worktree_index > 1 && branch == branch_name {
-                    return current_path;
-                }
-            }
-        } else if line.is_empty() {
-            current_path = None;
-        }
-    }
-
-    None
-}
-
-/// Find worktree path by absolute path
-///
-/// Uses canonicalization to match paths even when:
-/// - Input path is relative
-/// - Paths contain symlinks, `.` or `..` components
-///
-/// Returns None if path not found or is main worktree
-pub fn find_worktree_by_path(output: &str, target_path: &Path) -> Option<String> {
-    let mut worktree_index = 0;
-
-    for line in output.lines() {
-        if line.starts_with("worktree ") {
-            let current_path = line.strip_prefix("worktree ").map(String::from);
-            worktree_index += 1;
-
-            // Skip main worktree (index 1)
-            if worktree_index > 1 {
-                if let Some(path) = &current_path {
-                    let path_buf = PathBuf::from(path);
-                    let canonical_target = canonicalize_allow_missing(target_path);
-                    let canonical_worktree = canonicalize_allow_missing(&path_buf);
-
-                    if canonical_target == canonical_worktree {
-                        return current_path;
-                    }
-                }
-            }
-        }
-    }
-
-    None
-}
-
-/// Check if the given path or branch name refers to the main worktree
-/// This function is only used in tests
-#[cfg(test)]
-pub fn is_main_worktree(output: &str, path_or_branch: &str) -> bool {
-    // "@" is always main worktree
-    if path_or_branch == "@" {
-        return true;
-    }
-
-    let mut main_path: Option<String> = None;
-    let mut main_branch: Option<String> = None;
-    let mut worktree_index = 0;
-
-    for line in output.lines() {
-        if line.starts_with("worktree ") {
-            worktree_index += 1;
-            if worktree_index == 1 {
-                main_path = line.strip_prefix("worktree ").map(String::from);
-            }
-        } else if line.starts_with("branch ") && worktree_index == 1 {
-            if let Some(branch_ref) = line.strip_prefix("branch ") {
-                let branch = branch_ref.strip_prefix("refs/heads/").unwrap_or(branch_ref);
-                main_branch = Some(branch.to_string());
-            }
-        }
-
-        // Early exit if we have both and are past main worktree
-        if worktree_index > 1 && main_path.is_some() {
-            break;
-        }
-    }
-
-    // Check if matches main path or main branch
-    main_path.as_deref() == Some(path_or_branch) || main_branch.as_deref() == Some(path_or_branch)
-}
-
-/// Parse all worktrees and return (`main_path`, `Vec<(path, Option<branch>)>`)
-/// Returns the main worktree path and a list of all non-main worktrees
-pub fn parse_all_worktrees(output: &str) -> (String, Vec<(String, Option<String>)>) {
-    let mut main_path = String::new();
-    let mut worktrees = Vec::new();
-    let mut worktree_index = 0;
-    let mut current_path: Option<String> = None;
-    let mut current_branch: Option<String> = None;
-
-    for line in output.lines() {
-        if line.starts_with("worktree ") {
-            // Save previous worktree
-            if let Some(path) = current_path.take() {
-                if worktree_index == 1 {
-                    main_path = path;
-                } else {
-                    worktrees.push((path, current_branch.take()));
-                }
-            }
-            worktree_index += 1;
-            current_path = line.strip_prefix("worktree ").map(String::from);
-            current_branch = None;
-        } else if line.starts_with("branch ") {
-            if let Some(branch_ref) = line.strip_prefix("branch ") {
-                let branch = branch_ref.strip_prefix("refs/heads/").unwrap_or(branch_ref);
-                current_branch = Some(branch.to_string());
-            }
-        } else if line.is_empty() {
-            // End of worktree entry
-            if let Some(path) = current_path.take() {
-                if worktree_index == 1 {
-                    main_path = path;
-                } else {
-                    worktrees.push((path, current_branch.take()));
-                }
-            }
-        }
-    }
-
-    // Handle last worktree
-    if let Some(path) = current_path {
-        if worktree_index == 1 {
-            main_path = path;
-        } else {
-            worktrees.push((path, current_branch));
-        }
-    }
-
-    (main_path, worktrees)
 }
 
 /// Canonicalize a path, even if it doesn't exist on the filesystem
@@ -297,8 +152,12 @@ pub fn resolve_worktree_target(
         None
     };
 
-    // Parse all worktrees
-    let (main_path, worktrees) = parse_all_worktrees(list_stdout);
+    // Parse all worktrees once via the unified WorktreeList API.
+    let list = WorktreeList::parse(list_stdout, None);
+    let main_entry = list
+        .main()
+        .context("git worktree list returned no entries")?;
+    let main_path = main_entry.path.clone();
 
     // Check for main worktree
     if name == "@" {
@@ -308,13 +167,6 @@ pub fn resolve_worktree_target(
     let worktree_path: PathBuf;
     let branch_name: Option<String>;
     let canonical_path: PathBuf;
-
-    // Try to find by branch name first (to avoid conflicts with files/dirs of the same name)
-    let branch_match = if !is_current_worktree_removal && name != "@" {
-        find_worktree_by_branch(list_stdout, name)
-    } else {
-        None
-    };
 
     // Special handling for "." (current worktree)
     if let Some(current_path) = current_path_opt {
@@ -327,31 +179,27 @@ pub fn resolve_worktree_target(
             anyhow::bail!("Cannot remove main worktree");
         }
 
-        // Find branch name for current worktree
-        let mut current_branch: Option<String> = None;
-        for (path, branch) in &worktrees {
-            let path_buf = PathBuf::from(path);
-            let canonical_wt = canonicalize_allow_missing(&path_buf);
-            if canonical_wt == canonical_current {
-                current_branch.clone_from(branch);
-                break;
-            }
-        }
+        // Find branch name for current worktree among non-main entries
+        let current_branch = list
+            .non_main()
+            .iter()
+            .find(|e| canonicalize_allow_missing(&PathBuf::from(&e.path)) == canonical_current)
+            .and_then(|e| e.branch.clone());
 
         worktree_path = PathBuf::from(current_path);
         branch_name = current_branch;
         canonical_path = canonical_current;
-    } else if let Some(path) = branch_match {
-        // Found by branch name
-        worktree_path = PathBuf::from(&path);
+    } else if let Some(entry) = list.find_by_branch(name) {
+        // Found by branch name (excludes main automatically)
+        worktree_path = PathBuf::from(&entry.path);
         branch_name = Some(name.to_string());
-        let path_buf = PathBuf::from(&path);
-        canonical_path = canonicalize_allow_missing(&path_buf);
+        canonical_path = canonicalize_allow_missing(&worktree_path);
     } else {
         // Try to resolve as relative path from worktree root
-        let worktree_paths: Vec<PathBuf> = worktrees
+        let worktree_paths: Vec<PathBuf> = list
+            .non_main()
             .iter()
-            .map(|(path, _)| PathBuf::from(path))
+            .map(|e| PathBuf::from(&e.path))
             .collect();
 
         let relative_match = crate::domain::worktree::calculate_worktree_root_from_paths(
@@ -359,18 +207,12 @@ pub fn resolve_worktree_target(
         )
         .and_then(|root| {
             let abs_path = root.join(name);
-            find_worktree_by_path(list_stdout, &abs_path)
+            list.find_by_path(&abs_path).cloned()
         });
 
-        if let Some(ref_path) = relative_match {
-            // Look up branch name (ref_path is verbatim from porcelain output)
-            let matched_branch = worktrees
-                .iter()
-                .find(|(p, _)| p == &ref_path)
-                .and_then(|(_, branch)| branch.clone());
-
-            worktree_path = PathBuf::from(&ref_path);
-            branch_name = matched_branch;
+        if let Some(matched) = relative_match {
+            worktree_path = PathBuf::from(&matched.path);
+            branch_name = matched.branch;
             canonical_path = canonicalize_allow_missing(&worktree_path);
         } else {
             // Fallback: try to resolve as an absolute path
@@ -384,20 +226,9 @@ pub fn resolve_worktree_target(
                 anyhow::bail!("Cannot remove main worktree");
             }
 
-            // Check if it matches any known worktree path
-            let mut found_worktree = None;
-            for (path, branch) in &worktrees {
-                let path_buf = PathBuf::from(path);
-                let canonical_worktree = canonicalize_allow_missing(&path_buf);
-                if canonical_input == canonical_worktree {
-                    found_worktree = Some((path.clone(), branch.clone()));
-                    break;
-                }
-            }
-
-            if let Some((path, branch)) = found_worktree {
-                worktree_path = PathBuf::from(path);
-                branch_name = branch;
+            if let Some(entry) = list.find_by_path(&input_path_buf) {
+                worktree_path = PathBuf::from(&entry.path);
+                branch_name = entry.branch.clone();
                 canonical_path = canonical_input;
             } else {
                 anyhow::bail!("Worktree not found: {name}");
@@ -416,123 +247,6 @@ pub fn resolve_worktree_target(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
-
-    #[test]
-    fn test_find_worktree_by_branch_finds_path() {
-        let output = "worktree /path/to/main
-branch refs/heads/main
-
-worktree /path/to/feature
-branch refs/heads/feature
-
-worktree /path/to/bugfix
-branch refs/heads/bugfix
-
-";
-        let result = find_worktree_by_branch(output, "feature");
-        assert_eq!(result, Some("/path/to/feature".to_string()));
-    }
-
-    #[test]
-    fn test_find_worktree_by_branch_not_found() {
-        let output = "worktree /path/to/main
-branch refs/heads/main
-
-worktree /path/to/feature
-branch refs/heads/feature
-
-";
-        let result = find_worktree_by_branch(output, "nonexistent");
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_find_worktree_by_branch_main_not_found() {
-        let output = "worktree /path/to/main
-branch refs/heads/main
-
-worktree /path/to/feature
-branch refs/heads/feature
-
-";
-        // Main worktree should not be found (it's excluded)
-        let result = find_worktree_by_branch(output, "main");
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_find_worktree_by_path_exact_match() {
-        let output = "worktree /path/to/main
-branch refs/heads/main
-
-worktree /path/to/feature
-branch refs/heads/feature
-
-worktree /path/to/bugfix
-branch refs/heads/bugfix
-
-";
-        let result = find_worktree_by_path(output, &PathBuf::from("/path/to/feature"));
-        assert_eq!(result, Some("/path/to/feature".to_string()));
-    }
-
-    #[test]
-    fn test_find_worktree_by_path_not_found() {
-        let output = "worktree /path/to/main
-branch refs/heads/main
-
-worktree /path/to/feature
-branch refs/heads/feature
-
-";
-        let result = find_worktree_by_path(output, &PathBuf::from("/path/to/nonexistent"));
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_find_worktree_by_path_main_excluded() {
-        let output = "worktree /path/to/main
-branch refs/heads/main
-
-worktree /path/to/feature
-branch refs/heads/feature
-
-";
-        // Main worktree should not be found (it's excluded)
-        let result = find_worktree_by_path(output, &PathBuf::from("/path/to/main"));
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_is_main_worktree_by_path() {
-        let output = "worktree /path/to/main
-branch refs/heads/main
-
-worktree /path/to/feature
-branch refs/heads/feature
-
-";
-        assert!(is_main_worktree(output, "/path/to/main"));
-        assert!(!is_main_worktree(output, "/path/to/feature"));
-        assert!(!is_main_worktree(output, "/nonexistent"));
-    }
-
-    #[test]
-    fn test_is_main_worktree_by_branch() {
-        let output = "worktree /path/to/main
-branch refs/heads/develop
-
-worktree /path/to/feature
-branch refs/heads/feature
-
-";
-        // "@" is always treated as main worktree
-        assert!(is_main_worktree(output, "@"));
-        // Branch name matching main worktree's branch is also considered main
-        assert!(is_main_worktree(output, "develop"));
-        assert!(!is_main_worktree(output, "feature"));
-    }
 
     #[test]
     fn test_canonicalize_allow_missing_existing_path() {

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -10,8 +10,7 @@ use crate::color;
 use crate::commands::common::get_main_repo_root;
 use crate::config::Config;
 use crate::domain::worktree::{
-    format_worktree_table, get_last_commit_time, normalize_absolute_path,
-    parse_simple_worktree_entries, parse_worktree_entries,
+    format_worktree_table, get_last_commit_time, normalize_absolute_path, WorktreeList,
 };
 
 /// List all worktrees
@@ -48,7 +47,8 @@ pub fn cmd_list(show_path: bool, color_mode: color::ColorMode) -> Result<()> {
 
     if is_interactive {
         // Interactive mode: enhanced table to stderr (with colors if enabled)
-        let entries = parse_worktree_entries(&stdout, current_dir.as_deref());
+        let list = WorktreeList::parse(&stdout, current_dir.as_deref());
+        let entries = list.entries();
 
         // Get commit times for all worktrees
         let commit_times: Vec<Option<DateTime<Utc>>> = entries
@@ -58,7 +58,7 @@ pub fn cmd_list(show_path: bool, color_mode: color::ColorMode) -> Result<()> {
 
         // Format and print table to stderr (color_mode controls ANSI emission)
         let lines = format_worktree_table(
-            &entries,
+            entries,
             &commit_times,
             show_path,
             color_mode,
@@ -71,7 +71,8 @@ pub fn cmd_list(show_path: bool, color_mode: color::ColorMode) -> Result<()> {
         // Pipe mode: output to stdout (color_mode still controls ANSI emission)
         if show_path {
             // Full table output to stdout
-            let entries = parse_worktree_entries(&stdout, current_dir.as_deref());
+            let list = WorktreeList::parse(&stdout, current_dir.as_deref());
+            let entries = list.entries();
 
             let commit_times: Vec<Option<DateTime<Utc>>> = entries
                 .iter()
@@ -81,7 +82,7 @@ pub fn cmd_list(show_path: bool, color_mode: color::ColorMode) -> Result<()> {
             // Format and print table to stdout
             // color_mode determines whether ANSI codes are included
             let lines = format_worktree_table(
-                &entries,
+                entries,
                 &commit_times,
                 show_path,
                 color_mode,
@@ -91,10 +92,10 @@ pub fn cmd_list(show_path: bool, color_mode: color::ColorMode) -> Result<()> {
                 println!("{line}");
             }
         } else {
-            // Simple mode: branch names only - use lightweight parsing without hashes
-            let entries = parse_simple_worktree_entries(&stdout);
+            // Simple mode: branch names only — pipe-mode parse without active_path
+            let list = WorktreeList::parse(&stdout, None);
 
-            for (index, entry) in entries.iter().enumerate() {
+            for (index, entry) in list.entries().iter().enumerate() {
                 if index == 0 {
                     // Main worktree
                     println!("@");

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -5,11 +5,11 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::color;
-use crate::commands::common::{
-    canonicalize_allow_missing, get_main_repo_root, parse_all_worktrees,
-};
+use crate::commands::common::{canonicalize_allow_missing, get_main_repo_root};
 use crate::config;
-use crate::domain::worktree::{calculate_relative_path, calculate_worktree_root_from_paths};
+use crate::domain::worktree::{
+    calculate_relative_path, calculate_worktree_root_from_paths, WorktreeList,
+};
 use crate::integrations::tmux::{sanitize_window_name, RealTmuxLauncher, TmuxLauncher};
 
 /// Worktree entry for the open command
@@ -100,34 +100,6 @@ fn build_worktree_list(
     (result, skipped_name)
 }
 
-/// Parse main branch from porcelain output
-fn parse_main_branch(porcelain_output: &str) -> Option<String> {
-    let mut in_first_worktree = false;
-
-    for line in porcelain_output.lines() {
-        if line.starts_with("worktree ") {
-            if in_first_worktree {
-                // We've reached the second worktree without finding a branch
-                return None;
-            }
-            in_first_worktree = true;
-        } else if in_first_worktree {
-            if let Some(branch_ref) = line.strip_prefix("branch ") {
-                let branch = branch_ref.strip_prefix("refs/heads/").unwrap_or(branch_ref);
-                return Some(branch.to_string());
-            }
-            if line == "detached" {
-                return None;
-            }
-            if line.is_empty() {
-                return None;
-            }
-        }
-    }
-
-    None
-}
-
 /// Open all worktrees in tmux
 ///
 /// # Errors
@@ -154,19 +126,24 @@ pub fn cmd_open(pane: bool, window: bool, color_mode: color::ColorMode) -> Resul
     }
 
     let list_stdout = String::from_utf8_lossy(&output.stdout);
-    let (main_path, worktrees) = parse_all_worktrees(&list_stdout);
-    let main_branch = parse_main_branch(&list_stdout);
+    let list = WorktreeList::parse(&list_stdout, None);
+    let main_entry = list
+        .main()
+        .context("git worktree list returned no entries")?;
+    let main_path = main_entry.path.clone();
+    let main_branch = main_entry.branch.as_deref();
+    let worktrees: Vec<(String, Option<String>)> = list
+        .non_main()
+        .iter()
+        .map(|e| (e.path.clone(), e.branch.clone()))
+        .collect();
 
     // Detect current worktree
     let current_path = get_current_worktree_path()?;
 
     // Build list, skipping current worktree
-    let (open_list, skipped_name) = build_worktree_list(
-        &main_path,
-        main_branch.as_deref(),
-        &worktrees,
-        &current_path,
-    );
+    let (open_list, skipped_name) =
+        build_worktree_list(&main_path, main_branch, &worktrees, &current_path);
 
     if open_list.is_empty() {
         eprintln!("No worktrees to open (all worktrees are already in the current session).");
@@ -316,20 +293,23 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_main_branch_normal() {
+    fn test_main_branch_via_worktree_list_normal() {
         let porcelain = "worktree /path/to/main\nHEAD abc123\nbranch refs/heads/main\n\n";
-        assert_eq!(parse_main_branch(porcelain), Some("main".to_string()));
+        let list = WorktreeList::parse(porcelain, None);
+        assert_eq!(list.main().and_then(|m| m.branch.as_deref()), Some("main"));
     }
 
     #[test]
-    fn test_parse_main_branch_detached() {
+    fn test_main_branch_via_worktree_list_detached() {
         let porcelain = "worktree /path/to/main\nHEAD abc123\ndetached\n\n";
-        assert_eq!(parse_main_branch(porcelain), None);
+        let list = WorktreeList::parse(porcelain, None);
+        assert_eq!(list.main().and_then(|m| m.branch.as_deref()), None);
     }
 
     #[test]
-    fn test_parse_main_branch_empty() {
-        assert_eq!(parse_main_branch(""), None);
+    fn test_main_branch_via_worktree_list_empty() {
+        let list = WorktreeList::parse("", None);
+        assert!(list.main().is_none());
     }
 
     #[test]

--- a/src/commands/rm.rs
+++ b/src/commands/rm.rs
@@ -7,9 +7,9 @@ use std::process::Command;
 use std::time::Duration;
 
 use crate::color;
-use crate::commands::common::{get_main_repo_root, parse_all_worktrees, resolve_worktree_target};
+use crate::commands::common::{get_main_repo_root, resolve_worktree_target};
 use crate::config;
-use crate::domain::worktree::display_path;
+use crate::domain::worktree::{display_path, WorktreeList};
 use crate::hooks;
 use crate::integrations;
 use crate::integrations::fzf::FzfPicker;
@@ -267,7 +267,11 @@ pub fn cmd_rm_many(targets: &[String], color_mode: color::ColorMode) -> Result<(
         )?;
 
         // Print main worktree path for shell wrapper
-        let (main_path, _) = parse_all_worktrees(&list_stdout);
+        let list = WorktreeList::parse(&list_stdout, None);
+        let main_path = list
+            .main()
+            .map(|m| m.path.as_str())
+            .context("git worktree list returned no entries")?;
         println!("{main_path}");
     }
 

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -7,8 +7,9 @@ use std::process::Command;
 use std::time::Duration;
 
 use crate::color;
-use crate::commands::common::{get_main_repo_root, parse_all_worktrees};
+use crate::commands::common::get_main_repo_root;
 use crate::config::{self, HookActions};
+use crate::domain::worktree::WorktreeList;
 use crate::hooks;
 
 /// Sync hooks.create actions to all existing non-main worktrees
@@ -52,7 +53,8 @@ pub fn cmd_sync(run: bool, copy: bool, link: bool, color_mode: color::ColorMode)
     }
 
     let list_stdout = String::from_utf8_lossy(&output.stdout);
-    let (_main_path, worktrees) = parse_all_worktrees(&list_stdout);
+    let list = WorktreeList::parse(&list_stdout, None);
+    let worktrees = list.non_main();
 
     if worktrees.is_empty() {
         eprintln!("No non-main worktrees found. Nothing to sync.");
@@ -63,8 +65,9 @@ pub fn cmd_sync(run: bool, copy: bool, link: bool, color_mode: color::ColorMode)
     let is_tty = color_mode.should_colorize();
     let mut errors: Vec<String> = vec![];
 
-    for (path, branch) in &worktrees {
-        let label = branch.as_deref().unwrap_or(path.as_str());
+    for entry in worktrees {
+        let path = &entry.path;
+        let label = entry.branch.as_deref().unwrap_or(path.as_str());
 
         // Header spinner (TTY) or pre-printed header (non-TTY)
         let header_pb = if is_tty {

--- a/src/domain/worktree.rs
+++ b/src/domain/worktree.rs
@@ -9,19 +9,12 @@ use std::process::Command;
 use crate::color;
 use crate::commands::common::canonicalize_allow_missing;
 
-/// Simple worktree entry without hash information
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SimpleWorktreeEntry {
-    pub path: String,
-    pub branch: Option<String>,
-}
-
 /// Worktree entry for enhanced display
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorktreeEntry {
     pub path: String,
     pub branch: Option<String>,
-    pub hash: String,
+    pub hash: Option<String>,
     pub is_active: bool,
 }
 
@@ -33,83 +26,6 @@ struct WorktreeDisplay {
     branch: String,
     timestamp: String,
     is_active: bool,
-}
-
-/// Parse worktree list --porcelain output into structured entries
-///
-/// Returns a Vec of all worktrees (including main) with their commit hashes.
-/// Parses the HEAD line from porcelain output to avoid expensive git rev-parse calls.
-pub fn parse_worktree_entries(
-    output: &str,
-    active_path: Option<&std::path::Path>,
-) -> Vec<WorktreeEntry> {
-    let mut entries = Vec::new();
-    let mut current_path: Option<String> = None;
-    let mut current_branch: Option<String> = None;
-    let mut current_hash: Option<String> = None;
-
-    // Try to canonicalize active_path, but keep original if canonicalization fails
-    let canonical_active =
-        active_path.map(|p| p.canonicalize().unwrap_or_else(|_| p.to_path_buf()));
-
-    for line in output.lines() {
-        if line.starts_with("worktree ") {
-            // Save previous worktree
-            if let Some(path) = current_path.take() {
-                let hash = current_hash
-                    .take()
-                    .unwrap_or_else(|| "(unknown)".to_string());
-                let is_active = is_path_active(&path, canonical_active.as_ref());
-                entries.push(WorktreeEntry {
-                    path,
-                    branch: current_branch.take(),
-                    hash,
-                    is_active,
-                });
-            }
-            current_path = line.strip_prefix("worktree ").map(String::from);
-            current_branch = None;
-            current_hash = None;
-        } else if line.starts_with("HEAD ") {
-            // Parse HEAD hash and truncate to 8 characters
-            if let Some(full_hash) = line.strip_prefix("HEAD ") {
-                current_hash = Some(full_hash.chars().take(8).collect());
-            }
-        } else if line.starts_with("branch ") {
-            if let Some(branch_ref) = line.strip_prefix("branch ") {
-                let branch = branch_ref.strip_prefix("refs/heads/").unwrap_or(branch_ref);
-                current_branch = Some(branch.to_string());
-            }
-        } else if line.is_empty() {
-            // End of worktree entry
-            if let Some(path) = current_path.take() {
-                let hash = current_hash
-                    .take()
-                    .unwrap_or_else(|| "(unknown)".to_string());
-                let is_active = is_path_active(&path, canonical_active.as_ref());
-                entries.push(WorktreeEntry {
-                    path,
-                    branch: current_branch.take(),
-                    hash,
-                    is_active,
-                });
-            }
-        }
-    }
-
-    // Handle last worktree
-    if let Some(path) = current_path {
-        let hash = current_hash.unwrap_or_else(|| "(unknown)".to_string());
-        let is_active = is_path_active(&path, canonical_active.as_ref());
-        entries.push(WorktreeEntry {
-            path,
-            branch: current_branch,
-            hash,
-            is_active,
-        });
-    }
-
-    entries
 }
 
 /// Check if a worktree path matches the active path
@@ -125,49 +41,135 @@ fn is_path_active(worktree_path: &str, canonical_active: Option<&std::path::Path
     false
 }
 
-/// Parse worktree entries without expensive hash lookups (for pipe mode)
-/// Returns lightweight entries with only path and branch information
-pub fn parse_simple_worktree_entries(output: &str) -> Vec<SimpleWorktreeEntry> {
-    let mut entries = Vec::new();
-    let mut current_path: Option<String> = None;
-    let mut current_branch: Option<String> = None;
+/// Unified worktree list parsed from `git worktree list --porcelain` output.
+///
+/// Single parser + six query methods (`entries`, `main`, `non_main`,
+/// `find_by_branch`, `find_by_path`, `current`) replacing the previous family
+/// of standalone porcelain scanners scattered across `commands/*` and `cli.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeList {
+    entries: Vec<WorktreeEntry>,
+}
 
-    for line in output.lines() {
-        if line.starts_with("worktree ") {
-            // Save previous worktree
-            if let Some(path) = current_path.take() {
-                entries.push(SimpleWorktreeEntry {
-                    path,
-                    branch: current_branch.take(),
-                });
-            }
-            current_path = line.strip_prefix("worktree ").map(String::from);
-            current_branch = None;
-        } else if line.starts_with("branch ") {
-            if let Some(branch_ref) = line.strip_prefix("branch ") {
+impl WorktreeList {
+    /// Parse `git worktree list --porcelain` output.
+    ///
+    /// `active_path`: when `Some`, the matching entry's `is_active` field is set to `true`
+    /// using canonicalize-then-string-fallback comparison (same semantics as the legacy
+    /// `is_path_active` helper).
+    #[must_use]
+    pub fn parse(porcelain: &str, active_path: Option<&std::path::Path>) -> Self {
+        let mut entries = Vec::new();
+        let mut current_path: Option<String> = None;
+        let mut current_branch: Option<String> = None;
+        let mut current_hash: Option<String> = None;
+
+        let canonical_active =
+            active_path.map(|p| p.canonicalize().unwrap_or_else(|_| p.to_path_buf()));
+
+        for line in porcelain.lines() {
+            if let Some(path) = line.strip_prefix("worktree ") {
+                if let Some(prev_path) = current_path.take() {
+                    let is_active = is_path_active(&prev_path, canonical_active.as_ref());
+                    entries.push(WorktreeEntry {
+                        path: prev_path,
+                        branch: current_branch.take(),
+                        hash: current_hash.take(),
+                        is_active,
+                    });
+                }
+                current_path = Some(path.to_string());
+            } else if let Some(full_hash) = line.strip_prefix("HEAD ") {
+                current_hash = Some(full_hash.chars().take(8).collect());
+            } else if let Some(branch_ref) = line.strip_prefix("branch ") {
                 let branch = branch_ref.strip_prefix("refs/heads/").unwrap_or(branch_ref);
                 current_branch = Some(branch.to_string());
+            } else if line == "detached" {
+                current_branch = None;
+            } else if line.is_empty() {
+                if let Some(prev_path) = current_path.take() {
+                    let is_active = is_path_active(&prev_path, canonical_active.as_ref());
+                    entries.push(WorktreeEntry {
+                        path: prev_path,
+                        branch: current_branch.take(),
+                        hash: current_hash.take(),
+                        is_active,
+                    });
+                }
             }
-        } else if line.is_empty() {
-            // End of worktree entry
-            if let Some(path) = current_path.take() {
-                entries.push(SimpleWorktreeEntry {
-                    path,
-                    branch: current_branch.take(),
-                });
-            }
+        }
+
+        if let Some(prev_path) = current_path {
+            let is_active = is_path_active(&prev_path, canonical_active.as_ref());
+            entries.push(WorktreeEntry {
+                path: prev_path,
+                branch: current_branch,
+                hash: current_hash,
+                is_active,
+            });
+        }
+
+        Self { entries }
+    }
+
+    /// All worktree entries in the order returned by `git worktree list --porcelain`.
+    /// The main worktree (when present) is always at index 0.
+    #[must_use]
+    pub fn entries(&self) -> &[WorktreeEntry] {
+        &self.entries
+    }
+
+    /// The main worktree (index 0). Returns `None` when porcelain output yields no entries
+    /// (e.g. empty input, broken repo). git itself always emits at least one entry in
+    /// healthy repositories.
+    #[must_use]
+    pub fn main(&self) -> Option<&WorktreeEntry> {
+        self.entries.first()
+    }
+
+    /// All non-main worktree entries (everything after index 0). Empty when no extras exist.
+    #[must_use]
+    pub fn non_main(&self) -> &[WorktreeEntry] {
+        if self.entries.is_empty() {
+            &[]
+        } else {
+            &self.entries[1..]
         }
     }
 
-    // Handle last worktree
-    if let Some(path) = current_path {
-        entries.push(SimpleWorktreeEntry {
-            path,
-            branch: current_branch,
-        });
+    /// Find a non-main worktree by branch name (refs/heads/ already stripped).
+    /// Returns the first match. The main worktree is excluded so `find_by_branch("main")`
+    /// returns `None` when "main" is the main worktree's branch.
+    #[must_use]
+    pub fn find_by_branch(&self, branch_name: &str) -> Option<&WorktreeEntry> {
+        self.non_main()
+            .iter()
+            .find(|e| e.branch.as_deref() == Some(branch_name))
     }
 
-    entries
+    /// Find a non-main worktree by absolute or relative path.
+    /// Uses `canonicalize_allow_missing` for both sides so non-existent paths still compare
+    /// by their lexical normalization. The main worktree is excluded.
+    #[must_use]
+    pub fn find_by_path(&self, target: &std::path::Path) -> Option<&WorktreeEntry> {
+        let canonical_target = canonicalize_allow_missing(target);
+        self.non_main().iter().find(|e| {
+            let path_buf = std::path::PathBuf::from(&e.path);
+            canonicalize_allow_missing(&path_buf) == canonical_target
+        })
+    }
+
+    /// The currently-active worktree (matched against the `active_path` passed to `parse`).
+    /// Returns `None` when no `active_path` was provided, or when no entry matched.
+    ///
+    /// Production callers currently access `WorktreeEntry.is_active` directly via
+    /// `format_worktree_table`. This helper is part of the documented `WorktreeList`
+    /// API surface and is exercised by unit tests.
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn current(&self) -> Option<&WorktreeEntry> {
+        self.entries.iter().find(|e| e.is_active)
+    }
 }
 
 /// Get the last commit time for a worktree
@@ -476,7 +478,10 @@ pub fn format_worktree_table(
         } else {
             None
         };
-        let hash = entry.hash.clone();
+        let hash = entry
+            .hash
+            .clone()
+            .unwrap_or_else(|| "(unknown)".to_string());
 
         // Calculate relative path for non-main worktrees
         let rel_path = if index != 0 {
@@ -883,117 +888,6 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_worktree_entries_single_worktree() {
-        let output = "worktree /path/to/main
-HEAD 1234567890abcdef1234567890abcdef
-branch refs/heads/main
-
-";
-        let result = parse_worktree_entries(output, None);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].path, "/path/to/main");
-        assert_eq!(result[0].branch, Some("main".to_string()));
-        // Hash should be first 8 chars of HEAD
-        assert_eq!(result[0].hash, "12345678");
-    }
-
-    #[test]
-    fn test_parse_worktree_entries_multiple_worktrees() {
-        let output = "worktree /path/to/main
-HEAD 1234567890abcdef1234567890abcdef
-branch refs/heads/main
-
-worktree /path/to/feature
-HEAD abcdef1234567890abcdef1234567890
-branch refs/heads/feature
-
-worktree /path/to/bugfix
-HEAD fedcba0987654321fedcba0987654321
-branch refs/heads/bugfix
-
-";
-        let result = parse_worktree_entries(output, None);
-        assert_eq!(result.len(), 3);
-        assert_eq!(result[0].path, "/path/to/main");
-        assert_eq!(result[0].branch, Some("main".to_string()));
-        assert_eq!(result[0].hash, "12345678");
-
-        assert_eq!(result[1].path, "/path/to/feature");
-        assert_eq!(result[1].branch, Some("feature".to_string()));
-        assert_eq!(result[1].hash, "abcdef12");
-
-        assert_eq!(result[2].path, "/path/to/bugfix");
-        assert_eq!(result[2].branch, Some("bugfix".to_string()));
-        assert_eq!(result[2].hash, "fedcba09");
-    }
-
-    #[test]
-    fn test_parse_worktree_entries_detached_head() {
-        let output = "worktree /path/to/main
-HEAD 1234567890abcdef1234567890abcdef
-detached
-
-worktree /path/to/feature
-HEAD abcdef1234567890abcdef1234567890
-branch refs/heads/feature
-
-";
-        let result = parse_worktree_entries(output, None);
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].path, "/path/to/main");
-        assert_eq!(result[0].branch, None);
-        assert_eq!(result[0].hash, "12345678");
-
-        assert_eq!(result[1].path, "/path/to/feature");
-        assert_eq!(result[1].branch, Some("feature".to_string()));
-        assert_eq!(result[1].hash, "abcdef12");
-    }
-
-    #[test]
-    fn test_parse_worktree_entries_empty() {
-        let output = "";
-        let result = parse_worktree_entries(output, None);
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn test_parse_worktree_entries_with_active_path() {
-        let output = "worktree /path/to/main
-HEAD 1234567890abcdef1234567890abcdef
-branch refs/heads/main
-
-worktree /path/to/feature
-HEAD abcdef1234567890abcdef1234567890
-branch refs/heads/feature
-
-";
-        let active_path = std::path::PathBuf::from("/path/to/feature");
-        let result = parse_worktree_entries(output, Some(&active_path));
-
-        assert_eq!(result.len(), 2);
-        assert!(!result[0].is_active);
-        assert!(result[1].is_active);
-    }
-
-    #[test]
-    fn test_parse_worktree_entries_without_active_path() {
-        let output = "worktree /path/to/main
-HEAD 1234567890abcdef1234567890abcdef
-branch refs/heads/main
-
-worktree /path/to/feature
-HEAD abcdef1234567890abcdef1234567890
-branch refs/heads/feature
-
-";
-        let result = parse_worktree_entries(output, None);
-
-        assert_eq!(result.len(), 2);
-        assert!(!result[0].is_active);
-        assert!(!result[1].is_active);
-    }
-
-    #[test]
     fn test_get_last_commit_time_current_repo() {
         // Test with current repository (should have commits)
         let current_dir = std::env::current_dir().unwrap();
@@ -1015,7 +909,7 @@ branch refs/heads/feature
         let entries = vec![WorktreeEntry {
             path: "/path/to/main".to_string(),
             branch: Some("main".to_string()),
-            hash: "a1b2c3d4".to_string(),
+            hash: Some("a1b2c3d4".to_string()),
             is_active: false,
         }];
         let commit_times = vec![Some(
@@ -1042,7 +936,7 @@ branch refs/heads/feature
         let entries = vec![WorktreeEntry {
             path: "/path/to/main".to_string(),
             branch: Some("main".to_string()),
-            hash: "a1b2c3d4".to_string(),
+            hash: Some("a1b2c3d4".to_string()),
             is_active: false,
         }];
         let commit_times = vec![Some(
@@ -1070,13 +964,13 @@ branch refs/heads/feature
             WorktreeEntry {
                 path: "/path/to/main".to_string(),
                 branch: Some("main".to_string()),
-                hash: "a1b2c3d4".to_string(),
+                hash: Some("a1b2c3d4".to_string()),
                 is_active: false,
             },
             WorktreeEntry {
                 path: "/path/to/feature-branch".to_string(),
                 branch: Some("feature".to_string()),
-                hash: "e5f6g7h8".to_string(),
+                hash: Some("e5f6g7h8".to_string()),
                 is_active: false,
             },
         ];
@@ -1110,13 +1004,13 @@ branch refs/heads/feature
             WorktreeEntry {
                 path: "/short".to_string(),
                 branch: Some("a".to_string()),
-                hash: "12345678".to_string(),
+                hash: Some("12345678".to_string()),
                 is_active: false,
             },
             WorktreeEntry {
                 path: "/very/long/path/to/worktree".to_string(),
                 branch: Some("feature-branch".to_string()),
-                hash: "abcdefgh".to_string(),
+                hash: Some("abcdefgh".to_string()),
                 is_active: false,
             },
         ];
@@ -1150,7 +1044,7 @@ branch refs/heads/feature
         let entries = vec![WorktreeEntry {
             path: "/path/to/detached".to_string(),
             branch: None,
-            hash: "deadbeef".to_string(),
+            hash: Some("deadbeef".to_string()),
             is_active: false,
         }];
         let commit_times = vec![None];
@@ -1175,13 +1069,13 @@ branch refs/heads/feature
             WorktreeEntry {
                 path: "/path/to/main".to_string(),
                 branch: Some("main".to_string()),
-                hash: "a1b2c3d4".to_string(),
+                hash: Some("a1b2c3d4".to_string()),
                 is_active: false,
             },
             WorktreeEntry {
                 path: "/path/to/feature".to_string(),
                 branch: Some("feature".to_string()),
-                hash: "e5f6g7h8".to_string(),
+                hash: Some("e5f6g7h8".to_string()),
                 is_active: true,
             },
         ];
@@ -1208,13 +1102,13 @@ branch refs/heads/feature
             WorktreeEntry {
                 path: "/path/to/main".to_string(),
                 branch: Some("main".to_string()),
-                hash: "a1b2c3d4".to_string(),
+                hash: Some("a1b2c3d4".to_string()),
                 is_active: false,
             },
             WorktreeEntry {
                 path: "/path/to/feature".to_string(),
                 branch: Some("feature".to_string()),
-                hash: "e5f6g7h8".to_string(),
+                hash: Some("e5f6g7h8".to_string()),
                 is_active: true,
             },
         ];
@@ -1242,19 +1136,19 @@ branch refs/heads/feature
             WorktreeEntry {
                 path: "/Users/test/repo-worktrees/main".to_string(),
                 branch: Some("main".to_string()),
-                hash: "a1b2c3d4".to_string(),
+                hash: Some("a1b2c3d4".to_string()),
                 is_active: false,
             },
             WorktreeEntry {
                 path: "/Users/test/repo-worktrees/feature".to_string(),
                 branch: Some("feature".to_string()),
-                hash: "e5f6g7h8".to_string(),
+                hash: Some("e5f6g7h8".to_string()),
                 is_active: false,
             },
             WorktreeEntry {
                 path: "/Users/test/repo-worktrees/docs/tweak".to_string(),
                 branch: Some("docs/tweak".to_string()),
-                hash: "i9j0k1l2".to_string(),
+                hash: Some("i9j0k1l2".to_string()),
                 is_active: true,
             },
         ];
@@ -1300,73 +1194,253 @@ branch refs/heads/feature
         assert!(nested_line.starts_with("* ")); // Active marker
     }
 
-    // Tests for parse_simple_worktree_entries
-    #[test]
-    fn test_parse_simple_worktree_entries_single() {
-        let output = "worktree /path/to/main
-branch refs/heads/main
+    // -----------------------------------------------------------------
+    // WorktreeList tests (Step 2: porcelain parser unification)
+    // -----------------------------------------------------------------
 
-";
-        let result = parse_simple_worktree_entries(output);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].path, "/path/to/main");
-        assert_eq!(result[0].branch, Some("main".to_string()));
+    #[test]
+    fn test_worktree_list_parse_basic() {
+        let output = "worktree /path/to/main\nHEAD abc123def456789\nbranch refs/heads/main\n\nworktree /path/to/feat\nHEAD def456abc789012\nbranch refs/heads/feat\n\n";
+        let list = WorktreeList::parse(output, None);
+        assert_eq!(list.entries().len(), 2);
+        assert_eq!(list.entries()[0].path, "/path/to/main");
+        assert_eq!(list.entries()[0].branch.as_deref(), Some("main"));
+        assert_eq!(list.entries()[1].path, "/path/to/feat");
+        assert_eq!(list.entries()[1].branch.as_deref(), Some("feat"));
     }
 
     #[test]
-    fn test_parse_simple_worktree_entries_multiple() {
-        let output = "worktree /path/to/main
-branch refs/heads/main
-
-worktree /path/to/feature
-branch refs/heads/feature
-
-worktree /path/to/bugfix
-branch refs/heads/bugfix
-
-";
-        let result = parse_simple_worktree_entries(output);
-        assert_eq!(result.len(), 3);
-        assert_eq!(result[0].path, "/path/to/main");
-        assert_eq!(result[0].branch, Some("main".to_string()));
-        assert_eq!(result[1].path, "/path/to/feature");
-        assert_eq!(result[1].branch, Some("feature".to_string()));
-        assert_eq!(result[2].path, "/path/to/bugfix");
-        assert_eq!(result[2].branch, Some("bugfix".to_string()));
+    fn test_worktree_list_parse_detached_head_implicit() {
+        // Detached HEAD with no `branch` line and no explicit `detached` marker
+        let output = "worktree /path/to/main\nHEAD abc123def456789\nbranch refs/heads/main\n\nworktree /path/to/det\nHEAD aaaaaaaaaaaaaaaa\n\n";
+        let list = WorktreeList::parse(output, None);
+        assert_eq!(list.entries().len(), 2);
+        assert_eq!(list.entries()[1].branch, None);
     }
 
     #[test]
-    fn test_parse_simple_worktree_entries_detached() {
-        let output = "worktree /path/to/main
-detached
-
-worktree /path/to/feature
-branch refs/heads/feature
-
-";
-        let result = parse_simple_worktree_entries(output);
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].path, "/path/to/main");
-        assert_eq!(result[0].branch, None);
-        assert_eq!(result[1].path, "/path/to/feature");
-        assert_eq!(result[1].branch, Some("feature".to_string()));
+    fn test_worktree_list_parse_detached_head_explicit_marker() {
+        // Detached HEAD with explicit `detached` line (fzf.rs legacy behavior)
+        let output = "worktree /path/to/main\nHEAD abc123def456789\nbranch refs/heads/main\n\nworktree /path/to/det\nHEAD aaaaaaaaaaaaaaaa\ndetached\n\n";
+        let list = WorktreeList::parse(output, None);
+        assert_eq!(list.entries().len(), 2);
+        assert_eq!(list.entries()[1].branch, None);
     }
 
     #[test]
-    fn test_parse_simple_worktree_entries_empty() {
-        let output = "";
-        let result = parse_simple_worktree_entries(output);
-        assert!(result.is_empty());
+    fn test_worktree_list_parse_main_marker_at_index_0() {
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree /wt-a\nHEAD def67890xxxxxx\nbranch refs/heads/feature-a\n\n";
+        let list = WorktreeList::parse(output, None);
+        assert_eq!(list.entries()[0].path, "/repo");
+        assert_eq!(list.entries()[0].branch.as_deref(), Some("main"));
     }
 
     #[test]
-    fn test_parse_simple_worktree_entries_no_blank_lines() {
-        // Test without trailing blank lines
-        let output = "worktree /path/to/main
-branch refs/heads/main";
-        let result = parse_simple_worktree_entries(output);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].path, "/path/to/main");
-        assert_eq!(result[0].branch, Some("main".to_string()));
+    fn test_worktree_list_parse_branch_with_slash() {
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree /wt-feat\nHEAD def67890xxxxxx\nbranch refs/heads/feature/foo\n\nworktree /wt-rel\nHEAD eee99999xxxxxx\nbranch refs/heads/release/1.0\n\n";
+        let list = WorktreeList::parse(output, None);
+        assert_eq!(list.entries().len(), 3);
+        assert_eq!(list.entries()[1].branch.as_deref(), Some("feature/foo"));
+        assert_eq!(list.entries()[2].branch.as_deref(), Some("release/1.0"));
+    }
+
+    #[test]
+    fn test_worktree_list_parse_branch_with_at_sign() {
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree /wt-v2\nHEAD def67890xxxxxx\nbranch refs/heads/feature@v2\n\n";
+        let list = WorktreeList::parse(output, None);
+        assert_eq!(list.entries().len(), 2);
+        assert_eq!(list.entries()[1].branch.as_deref(), Some("feature@v2"));
+    }
+
+    #[test]
+    fn test_worktree_list_parse_trailing_newline_missing() {
+        // Missing trailing blank line — last entry must still be captured
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree /wt-a\nHEAD def67890xxxxxx\nbranch refs/heads/feature-a";
+        let list = WorktreeList::parse(output, None);
+        assert_eq!(list.entries().len(), 2);
+        assert_eq!(list.entries()[1].path, "/wt-a");
+        assert_eq!(list.entries()[1].branch.as_deref(), Some("feature-a"));
+    }
+
+    #[test]
+    fn test_worktree_list_parse_main_only_trailing_newline_missing() {
+        // Single main entry without trailing newline; main() must not return None
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main";
+        let list = WorktreeList::parse(output, None);
+        assert!(list.main().is_some());
+        assert_eq!(list.main().unwrap().path, "/repo");
+        assert_eq!(list.main().unwrap().branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn test_worktree_list_parse_single_entry() {
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\n";
+        let list = WorktreeList::parse(output, None);
+        assert_eq!(list.entries().len(), 1);
+        assert!(list.non_main().is_empty());
+    }
+
+    #[test]
+    fn test_worktree_list_parse_empty_input() {
+        let list = WorktreeList::parse("", None);
+        assert!(list.entries().is_empty());
+        assert!(list.main().is_none());
+        assert!(list.non_main().is_empty());
+    }
+
+    #[test]
+    fn test_worktree_list_parse_no_trim_required_on_canonical_git_output() {
+        // Canonical git porcelain output has no leading/trailing whitespace per line
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree /wt\nHEAD def67890xxxxxx\nbranch refs/heads/feat\n\n";
+        let list = WorktreeList::parse(output, None);
+        assert_eq!(list.entries().len(), 2);
+        assert_eq!(list.entries()[0].path, "/repo");
+        assert_eq!(list.entries()[1].path, "/wt");
+        assert_eq!(list.entries()[1].branch.as_deref(), Some("feat"));
+    }
+
+    #[test]
+    fn test_worktree_list_parse_malformed_branch_before_worktree_panic_free() {
+        // Malformed input where `branch` line appears before any `worktree` line
+        // Must not panic; behavior is best-effort (the orphan branch is dropped)
+        let output = "branch refs/heads/orphan\nworktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\n";
+        let list = WorktreeList::parse(output, None);
+        assert_eq!(list.entries().len(), 1);
+        assert_eq!(list.entries()[0].path, "/repo");
+        assert_eq!(list.entries()[0].branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn test_worktree_list_main_returns_first_entry_when_present() {
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree /wt\nHEAD def67890xxxxxx\nbranch refs/heads/feat\n\n";
+        let list = WorktreeList::parse(output, None);
+        assert!(list.main().is_some());
+        assert_eq!(list.main().unwrap().path, "/repo");
+    }
+
+    #[test]
+    fn test_worktree_list_main_returns_none_on_empty_list() {
+        let list = WorktreeList::parse("", None);
+        assert!(list.main().is_none());
+    }
+
+    #[test]
+    fn test_worktree_list_non_main_excludes_first() {
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree /wt-a\nHEAD def67890xxxxxx\nbranch refs/heads/feature-a\n\nworktree /wt-b\nHEAD eee99999xxxxxx\nbranch refs/heads/feature-b\n\n";
+        let list = WorktreeList::parse(output, None);
+        let non_main = list.non_main();
+        assert_eq!(non_main.len(), 2);
+        assert_eq!(non_main[0].path, "/wt-a");
+        assert_eq!(non_main[1].path, "/wt-b");
+    }
+
+    #[test]
+    fn test_worktree_list_find_by_branch_hits() {
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree /wt-a\nHEAD def67890xxxxxx\nbranch refs/heads/feature-a\n\n";
+        let list = WorktreeList::parse(output, None);
+        let entry = list.find_by_branch("feature-a");
+        assert!(entry.is_some());
+        assert_eq!(entry.unwrap().path, "/wt-a");
+    }
+
+    #[test]
+    fn test_worktree_list_find_by_branch_misses() {
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree /wt-a\nHEAD def67890xxxxxx\nbranch refs/heads/feature-a\n\n";
+        let list = WorktreeList::parse(output, None);
+        assert!(list.find_by_branch("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_worktree_list_find_by_branch_main_excluded() {
+        // find_by_branch must not return the main worktree even if branch matches
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree /wt-a\nHEAD def67890xxxxxx\nbranch refs/heads/feature-a\n\n";
+        let list = WorktreeList::parse(output, None);
+        assert!(list.find_by_branch("main").is_none());
+    }
+
+    #[test]
+    fn test_worktree_list_find_by_branch_first_match_wins_on_duplicate() {
+        // Abnormal input: same branch on two non-main worktrees — first wins
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree /wt-first\nHEAD def67890xxxxxx\nbranch refs/heads/dup\n\nworktree /wt-second\nHEAD eee99999xxxxxx\nbranch refs/heads/dup\n\n";
+        let list = WorktreeList::parse(output, None);
+        let entry = list.find_by_branch("dup");
+        assert!(entry.is_some());
+        assert_eq!(entry.unwrap().path, "/wt-first");
+    }
+
+    #[test]
+    fn test_worktree_list_find_by_path_canonicalize_match() {
+        // Use /tmp which always exists for canonicalize success path
+        let tmp_canonical = std::fs::canonicalize("/tmp").unwrap();
+        let tmp_str = tmp_canonical.to_string_lossy();
+        let output = format!(
+            "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree {tmp_str}\nHEAD def67890xxxxxx\nbranch refs/heads/feat\n\n"
+        );
+        let list = WorktreeList::parse(&output, None);
+        let entry = list.find_by_path(std::path::Path::new("/tmp"));
+        assert!(entry.is_some());
+        assert_eq!(entry.unwrap().path, tmp_str.as_ref());
+    }
+
+    #[test]
+    fn test_worktree_list_find_by_path_string_fallback() {
+        // Non-existent path — string comparison fallback path
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree /nonexistent/path/wt\nHEAD def67890xxxxxx\nbranch refs/heads/feat\n\n";
+        let list = WorktreeList::parse(output, None);
+        let entry = list.find_by_path(std::path::Path::new("/nonexistent/path/wt"));
+        assert!(entry.is_some());
+        assert_eq!(entry.unwrap().path, "/nonexistent/path/wt");
+    }
+
+    #[test]
+    fn test_worktree_list_find_by_path_main_excluded() {
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree /wt-a\nHEAD def67890xxxxxx\nbranch refs/heads/feature-a\n\n";
+        let list = WorktreeList::parse(output, None);
+        assert!(list.find_by_path(std::path::Path::new("/repo")).is_none());
+    }
+
+    #[test]
+    fn test_worktree_list_current_with_active_path_canonicalize() {
+        let tmp_canonical = std::fs::canonicalize("/tmp").unwrap();
+        let tmp_str = tmp_canonical.to_string_lossy();
+        let output = format!(
+            "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree {tmp_str}\nHEAD def67890xxxxxx\nbranch refs/heads/feat\n\n"
+        );
+        let list = WorktreeList::parse(&output, Some(std::path::Path::new("/tmp")));
+        let cur = list.current();
+        assert!(cur.is_some());
+        assert_eq!(cur.unwrap().path, tmp_str.as_ref());
+    }
+
+    #[test]
+    fn test_worktree_list_current_with_active_path_string_fallback() {
+        // Non-existent active path — string comparison fallback
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree /nonexistent/wt\nHEAD def67890xxxxxx\nbranch refs/heads/feat\n\n";
+        let list = WorktreeList::parse(output, Some(std::path::Path::new("/nonexistent/wt")));
+        let cur = list.current();
+        assert!(cur.is_some());
+        assert_eq!(cur.unwrap().path, "/nonexistent/wt");
+    }
+
+    #[test]
+    fn test_worktree_list_current_no_active_returns_none() {
+        let output = "worktree /repo\nHEAD abc12345xxxxxx\nbranch refs/heads/main\n\nworktree /wt-a\nHEAD def67890xxxxxx\nbranch refs/heads/feature-a\n\n";
+        let list = WorktreeList::parse(output, None);
+        assert!(list.current().is_none());
+    }
+
+    #[test]
+    fn test_worktree_list_hash_truncated_to_8_chars() {
+        let output = "worktree /repo\nHEAD abc12345def67890\nbranch refs/heads/main\n\n";
+        let list = WorktreeList::parse(output, None);
+        assert_eq!(list.entries()[0].hash.as_deref(), Some("abc12345"));
+    }
+
+    #[test]
+    fn test_worktree_list_hash_none_when_head_line_missing() {
+        // No HEAD line — hash should be None (pipe-mode behavior)
+        let output = "worktree /repo\nbranch refs/heads/main\n\n";
+        let list = WorktreeList::parse(output, None);
+        assert_eq!(list.entries()[0].hash, None);
     }
 }

--- a/src/integrations/fzf.rs
+++ b/src/integrations/fzf.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 use crate::domain::worktree::{
-    calculate_relative_path, calculate_worktree_root_from_paths, display_path,
+    calculate_relative_path, calculate_worktree_root_from_paths, display_path, WorktreeList,
 };
 
 /// Item to display in fzf
@@ -132,12 +132,6 @@ pub fn is_fzf_available() -> bool {
         .is_ok_and(|output| output.status.success())
 }
 
-/// Intermediate parsed worktree entry for fzf display
-struct ParsedWorktree {
-    path: String,
-    branch: Option<String>,
-}
-
 /// Build worktree items from git worktree list --porcelain output
 ///
 /// Display format: `{name} · {branch} · {path}`
@@ -145,50 +139,21 @@ struct ParsedWorktree {
 /// - Non-main worktrees show their relative path from the worktree root
 /// - Columns are padded for alignment (except the last column)
 pub fn build_worktree_items(porcelain_output: &str) -> Vec<FzfItem> {
-    // Pass 1: Parse porcelain output into intermediate entries
-    let mut entries = Vec::new();
-    let mut current_path: Option<String> = None;
-    let mut current_branch: Option<String> = None;
-
-    for line in porcelain_output.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            if let Some(path) = current_path.take() {
-                entries.push(ParsedWorktree {
-                    path,
-                    branch: current_branch.take(),
-                });
-            }
-            continue;
-        }
-
-        if let Some(path) = line.strip_prefix("worktree ") {
-            current_path = Some(path.to_string());
-        } else if let Some(branch_ref) = line.strip_prefix("branch ") {
-            if let Some(branch_name) = branch_ref.strip_prefix("refs/heads/") {
-                current_branch = Some(branch_name.to_string());
-            }
-        } else if line == "detached" {
-            current_branch = None;
-        }
-    }
-
-    // Handle last entry if output doesn't end with empty line
-    if let Some(path) = current_path {
-        entries.push(ParsedWorktree {
-            path,
-            branch: current_branch,
-        });
-    }
+    // Parse via the unified WorktreeList type (replaces the previous Pass 1
+    // independent scanner). Real `git worktree list --porcelain` output never
+    // has leading/trailing whitespace, so the legacy `.trim()` defense is
+    // dropped — covered by `test_build_worktree_items_no_trim_behavior_equivalent`.
+    let list = WorktreeList::parse(porcelain_output, None);
+    let entries = list.entries();
 
     if entries.is_empty() {
         return Vec::new();
     }
 
     // Calculate worktree root from non-main paths
-    let non_main_paths: Vec<PathBuf> = entries
+    let non_main_paths: Vec<PathBuf> = list
+        .non_main()
         .iter()
-        .skip(1)
         .map(|e| PathBuf::from(&e.path))
         .collect();
     let worktree_root = calculate_worktree_root_from_paths(&non_main_paths);
@@ -485,5 +450,31 @@ branch refs/heads/feature-branch
                 item.display
             );
         }
+    }
+
+    #[test]
+    fn test_build_worktree_items_no_trim_behavior_equivalent() {
+        // Canonical git worktree list --porcelain output: no leading/trailing whitespace.
+        // After WorktreeList unification the legacy `.trim()` defense was dropped.
+        // This test pins display equivalence on canonical input so any future regression
+        // in the unified parser surfaces here.
+        let porcelain = "worktree /path/to/main\nHEAD abc123\nbranch refs/heads/main\n\nworktree /worktrees/feature\nHEAD def456\nbranch refs/heads/feature\n\n";
+        let items = build_worktree_items(porcelain);
+        assert_eq!(items.len(), 2);
+        // Main entry — name `@`, branch `[@]`
+        assert!(items[0].display.starts_with('@'), "main name marker");
+        assert!(
+            items[0].display.contains("[@]"),
+            "main branch marker [@] present: {}",
+            items[0].display
+        );
+        // Non-main entry — branch `[feature]`
+        assert!(
+            items[1].display.contains("[feature]"),
+            "feature branch marker present: {}",
+            items[1].display
+        );
+        assert_eq!(items[0].value, "/path/to/main");
+        assert_eq!(items[1].value, "/worktrees/feature");
     }
 }


### PR DESCRIPTION
## Summary

Unify the 7 standalone `git worktree list --porcelain` parser functions plus the independent scanner in `cd.rs` (eight parse sites in total) into a single `WorktreeList` type that owns one parse pass and exposes six query methods: `entries / main / non_main / find_by_branch / find_by_path / current`.

- **9 caller sites migrated** across `commands/{rm, sync, list, open, cd, common}.rs`, `cli.rs`, and `integrations/fzf.rs`.
- **8 legacy parsers removed**: `parse_worktree_entries`, `parse_simple_worktree_entries`, `parse_all_worktrees`, `parse_worktree_list`, `parse_main_branch`, `find_worktree_by_branch`, `find_worktree_by_path`, `is_main_worktree`. `SimpleWorktreeEntry` shim is also removed.
- **`WorktreeEntry.hash` is now `Option<String>`** (was `String` with `"(unknown)"` sentinel). `format_worktree_table` unwraps with the existing sentinel at display time so column alignment and `ofsht ls` output are byte-identical to the pre-change snapshot.
- **`WorktreeList::main()` returns `Option<&WorktreeEntry>`** (panic-free for the corner case of an empty `git worktree list` response).
- **Defensive `.trim()` removed** from `fzf.rs::build_worktree_items` — real git porcelain output never has leading/trailing whitespace per line. A regression test pins display equivalence on canonical input.
- **Latent inconsistency fixed in completion**: the previous `parse_worktree_list` used `worktree_index > 0` at one save path and `> 1` elsewhere. With missing entry separators (malformed porcelain) this could leak the main branch into completion candidates. The new unified parser uses index-0-is-main semantics throughout, and a new regression test (`test_completion_excludes_main_branch_for_malformed_separator_missing`) pins the corrected behavior.

### Tests

- `cargo test`: 621 passed across 13 suites (601 baseline + 27 new `WorktreeList` unit tests + 1 cli regression + 1 fzf regression − parser-specific tests now covered by the unit tests).
- `ofsht ls` TTY and pipe output: byte-identical to the pre-change snapshot.
- `just check`: green (`fmt-ci`, `clippy-ci -D warnings`, full test suite, build).

### Step in the broader refactoring plan

Step 2 of the ofsht refactoring plan (Observation 4 in the Obsidian audit). Sets up Step 3 (`GitClient` trait expansion) by giving `GitClient::worktree_list` a unified return type to land on.

## References

- Step 1 (PR #100): test redistribution from `main.rs`
- Plan: `~/.claude/plans/20260504T1113-worktree-list-unification.md` (local)
