### PR TITLE
refactor: route all git ops through GitClient and connect WorktreeService

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,8 @@ use clap_complete::engine::{ArgValueCompleter, CompletionCandidate};
 use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::path::PathBuf;
-use std::process::Command;
+
+use crate::integrations::git::{GitClient, RealGitClient};
 
 /// Git worktree management tool
 #[derive(Parser, Debug)]
@@ -127,27 +128,17 @@ pub enum Commands {
 /// Excludes symbolic refs like origin/HEAD
 #[must_use]
 pub fn list_git_refs(current: &OsStr) -> Vec<CompletionCandidate> {
-    let output = Command::new("git")
-        .args([
-            "for-each-ref",
-            "--format=%(refname:short)%09%(symref)",
-            "refs/heads",
-            "refs/remotes",
-            "refs/tags",
-        ])
-        .output();
-
-    let Ok(output) = output else {
+    let git = RealGitClient;
+    let Ok(stdout) = git.for_each_ref(
+        &["refs/heads", "refs/remotes", "refs/tags"],
+        "%(refname:short)%09%(symref)",
+    ) else {
         return Vec::new();
     };
 
-    if !output.status.success() {
-        return Vec::new();
-    }
-
     let prefix = current.to_string_lossy();
 
-    String::from_utf8_lossy(&output.stdout)
+    stdout
         .lines()
         .filter_map(|line| {
             let parts: Vec<&str> = line.split('\t').collect();
@@ -178,26 +169,17 @@ pub fn list_git_refs(current: &OsStr) -> Vec<CompletionCandidate> {
 #[must_use]
 #[allow(dead_code)] // Reserved for future use
 pub fn list_git_branches(current: &OsStr) -> Vec<CompletionCandidate> {
-    let output = Command::new("git")
-        .args([
-            "for-each-ref",
-            "--format=%(refname:short)%09%(symref)",
-            "refs/heads",
-            "refs/remotes",
-        ])
-        .output();
-
-    let Ok(output) = output else {
+    let git = RealGitClient;
+    let Ok(stdout) = git.for_each_ref(
+        &["refs/heads", "refs/remotes"],
+        "%(refname:short)%09%(symref)",
+    ) else {
         return Vec::new();
     };
 
-    if !output.status.success() {
-        return Vec::new();
-    }
-
     let prefix = current.to_string_lossy();
 
-    String::from_utf8_lossy(&output.stdout)
+    stdout
         .lines()
         .filter_map(|line| {
             let parts: Vec<&str> = line.split('\t').collect();
@@ -225,20 +207,12 @@ pub fn list_git_branches(current: &OsStr) -> Vec<CompletionCandidate> {
 /// Filters worktree branch names by the provided prefix
 /// Includes "@" as the main worktree
 pub fn list_git_worktrees(current: &OsStr) -> Vec<CompletionCandidate> {
-    let output = Command::new("git")
-        .args(["worktree", "list", "--porcelain"])
-        .output();
-
-    let Ok(output) = output else {
+    let git = RealGitClient;
+    let Ok(stdout) = git.list_worktrees(None) else {
         return Vec::new();
     };
 
-    if !output.status.success() {
-        return Vec::new();
-    }
-
     let prefix = current.to_string_lossy();
-    let stdout = String::from_utf8_lossy(&output.stdout);
 
     // Use HashSet to deduplicate branch names and relative paths
     let mut candidates_set = HashSet::new();

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -2,7 +2,6 @@
 
 use anyhow::{Context, Result};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use std::process::Command;
 use std::time::Duration;
 
 use crate::color;
@@ -11,6 +10,7 @@ use crate::config;
 use crate::domain::worktree::normalize_absolute_path;
 use crate::hooks;
 use crate::integrations;
+use crate::integrations::git::{GitClient, RealGitClient};
 use crate::integrations::tmux::TmuxLauncher;
 
 /// Process a PR and return branch name and start point
@@ -23,25 +23,17 @@ fn process_pr(
     // Check if it's from a fork (cross-repository PR)
     let is_fork = pr.is_cross_repository;
 
+    let git = RealGitClient;
     if is_fork {
         // Fork PR - fetch PR ref from GitHub without checking out
-        let fetch_output = Command::new("git")
-            .args(["fetch", "origin", &format!("refs/pull/{number}/head")])
-            .current_dir(repo_root)
-            .output()
-            .context("Failed to execute git fetch")?;
-
-        if !fetch_output.status.success() {
-            let stderr = String::from_utf8_lossy(&fetch_output.stderr);
-            anyhow::bail!("git fetch PR ref failed: {stderr}");
-        }
+        git.fetch(
+            &["fetch", "origin", &format!("refs/pull/{number}/head")],
+            Some(repo_root),
+        )
+        .map_err(|e| anyhow::anyhow!("git fetch PR ref failed: {e}"))?;
 
         // Check if local branch with PR's name already exists
-        let branch_exists = Command::new("git")
-            .args(["rev-parse", "--verify", &pr.head_ref_name])
-            .current_dir(repo_root)
-            .output()
-            .is_ok_and(|o| o.status.success());
+        let branch_exists = git.branch_exists(&pr.head_ref_name, Some(repo_root));
 
         eprintln!(
             "{}",
@@ -74,16 +66,8 @@ fn process_pr(
         }
     } else {
         // Same repository - fetch the branch
-        let fetch_output = Command::new("git")
-            .args(["fetch", "origin", &pr.head_ref_name])
-            .current_dir(repo_root)
-            .output()
-            .context("Failed to execute git fetch")?;
-
-        if !fetch_output.status.success() {
-            let stderr = String::from_utf8_lossy(&fetch_output.stderr);
-            anyhow::bail!("git fetch failed: {stderr}");
-        }
+        git.fetch(&["fetch", "origin", &pr.head_ref_name], Some(repo_root))
+            .map_err(|e| anyhow::anyhow!("git fetch failed: {e}"))?;
 
         eprintln!(
             "{}",
@@ -94,11 +78,7 @@ fn process_pr(
         );
 
         // Check if local branch already exists
-        let branch_exists = Command::new("git")
-            .args(["rev-parse", "--verify", &pr.head_ref_name])
-            .current_dir(repo_root)
-            .output()
-            .is_ok_and(|o| o.status.success());
+        let branch_exists = git.branch_exists(&pr.head_ref_name, Some(repo_root));
 
         if branch_exists {
             // Existing local branch - use it directly
@@ -277,43 +257,13 @@ pub fn cmd_new(
         None
     };
 
-    // Create worktree using git worktree add
-    let mut cmd = Command::new("git");
-
-    if let Some(sp) = start_point {
-        // Create new branch with start point
-        cmd.args(["worktree", "add", "-b", branch])
-            .arg(&worktree_path)
-            .arg(sp);
-    } else {
-        // No start_point: try to checkout existing branch, or create from HEAD
-        // Check if branch exists
-        let branch_exists = Command::new("git")
-            .args(["rev-parse", "--verify", branch])
-            .current_dir(&repo_root)
-            .output()
-            .is_ok_and(|o| o.status.success());
-
-        if branch_exists {
-            // Checkout existing branch (no -b flag)
-            cmd.args(["worktree", "add"])
-                .arg(&worktree_path)
-                .arg(branch);
-        } else {
-            // Create new branch from HEAD
-            cmd.args(["worktree", "add", "-b", branch])
-                .arg(&worktree_path);
-        }
-    }
-
-    let output = cmd.output().context("Failed to execute git worktree add")?;
-
-    if !output.status.success() {
+    // Create worktree (RealGitClient handles the new/existing-branch dispatch internally)
+    let git = RealGitClient;
+    if let Err(e) = git.create_worktree(branch, &worktree_path, start_point, Some(&repo_root)) {
         if let Some(pb) = header_pb {
             pb.finish_and_clear();
         }
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git worktree add failed: {stderr}");
+        return Err(e);
     }
 
     // non-TTY: print header before hooks (rm/sync pattern)

--- a/src/commands/cd.rs
+++ b/src/commands/cd.rs
@@ -2,13 +2,13 @@
 
 use anyhow::{Context, Result};
 use std::path::PathBuf;
-use std::process::Command;
 
 use crate::commands::common::get_main_repo_root;
 use crate::config;
 use crate::domain::worktree::{normalize_absolute_path, WorktreeList};
 use crate::integrations;
 use crate::integrations::fzf::FzfPicker;
+use crate::integrations::git::{GitClient, RealGitClient};
 
 /// Navigate to a worktree by branch name
 ///
@@ -19,17 +19,8 @@ use crate::integrations::fzf::FzfPicker;
 /// - Fzf is required but not available
 pub fn cmd_goto(name: Option<&str>, _color_mode: crate::color::ColorMode) -> Result<()> {
     // Get worktree list
-    let output = Command::new("git")
-        .args(["worktree", "list", "--porcelain"])
-        .output()
-        .context("Failed to execute git worktree list")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git worktree list failed: {stderr}");
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let git = RealGitClient;
+    let stdout = git.list_worktrees(None)?;
 
     // Resolve name: CLI arg > stdin (when piped) > fzf
     let resolved_name: Option<String> = match name {

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -4,9 +4,9 @@
 
 use anyhow::{Context, Result};
 use std::path::{Component, Path, PathBuf};
-use std::process::Command;
 
 use crate::domain::worktree::WorktreeList;
+use crate::integrations::git::{GitClient, RealGitClient};
 
 /// Get the main repository root path
 ///
@@ -16,20 +16,16 @@ use crate::domain::worktree::WorktreeList;
 /// - Git command fails
 /// - Path canonicalization fails
 pub fn get_main_repo_root() -> Result<PathBuf> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--git-common-dir"])
-        .output()
-        .context("Failed to execute git rev-parse")?;
+    let git = RealGitClient;
+    let stdout = git
+        .rev_parse(&["rev-parse", "--git-common-dir"], None)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Not in a git repository. Please run ofsht from within a git repository.\nGit error: {e}"
+            )
+        })?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!(
-            "Not in a git repository. Please run ofsht from within a git repository.\nGit error: {}",
-            stderr.trim()
-        );
-    }
-
-    let git_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let git_dir = stdout.trim().to_string();
     let git_path = PathBuf::from(&git_dir);
 
     // Convert relative path to absolute
@@ -133,21 +129,11 @@ pub fn resolve_worktree_target(
 
     // Get current path if resolving "."
     let current_path_opt = if is_current_worktree_removal {
-        let current_output = Command::new("git")
-            .args(["rev-parse", "--show-toplevel"])
-            .output()
-            .context("Failed to get current worktree path")?;
-
-        if !current_output.status.success() {
-            let stderr = String::from_utf8_lossy(&current_output.stderr);
-            anyhow::bail!("Not in a git repository: {stderr}");
-        }
-
-        Some(
-            String::from_utf8_lossy(&current_output.stdout)
-                .trim()
-                .to_string(),
-        )
+        let git = RealGitClient;
+        let stdout = git
+            .rev_parse(&["rev-parse", "--show-toplevel"], None)
+            .map_err(|e| anyhow::anyhow!("Not in a git repository: {e}"))?;
+        Some(stdout.trim().to_string())
     } else {
         None
     };

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -2,7 +2,6 @@
 
 use anyhow::{Context, Result};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use std::process::Command;
 use std::time::Duration;
 
 use crate::color;
@@ -10,7 +9,9 @@ use crate::commands::common::get_main_repo_root;
 use crate::config;
 use crate::domain::worktree::display_path;
 use crate::hooks;
-use crate::integrations;
+use crate::integrations::git::RealGitClient;
+use crate::integrations::zoxide::{is_zoxide_available, RealZoxideClient};
+use crate::service::WorktreeService;
 
 /// Create a new worktree (simple version without tmux/GitHub integration)
 ///
@@ -59,35 +60,6 @@ pub fn cmd_create(
         repo_root.join(&path_template)
     };
 
-    // Create worktree using git worktree add
-    let mut cmd = Command::new("git");
-
-    if let Some(sp) = start_point {
-        // Create new branch with start point
-        cmd.args(["worktree", "add", "-b", branch])
-            .arg(&worktree_path)
-            .arg(sp);
-    } else {
-        // No start_point: try to checkout existing branch, or create from HEAD
-        // Check if branch exists
-        let branch_exists = Command::new("git")
-            .args(["rev-parse", "--verify", branch])
-            .current_dir(&repo_root)
-            .output()
-            .is_ok_and(|o| o.status.success());
-
-        if branch_exists {
-            // Checkout existing branch (no -b flag)
-            cmd.args(["worktree", "add"])
-                .arg(&worktree_path)
-                .arg(branch);
-        } else {
-            // Create new branch from HEAD
-            cmd.args(["worktree", "add", "-b", branch])
-                .arg(&worktree_path);
-        }
-    }
-
     let mp = MultiProgress::new();
     let is_tty = color_mode.should_colorize();
 
@@ -106,48 +78,68 @@ pub fn cmd_create(
         None
     };
 
-    let output = cmd.output().context("Failed to execute git worktree add")?;
+    // Resolve zoxide gating before handing control to the service so the
+    // service does not need to know about zoxide-availability detection.
+    let zoxide_enabled = config.integrations.zoxide.enabled && is_zoxide_available();
 
-    if !output.status.success() {
-        if let Some(pb) = header_pb {
-            pb.finish_and_clear();
-        }
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git worktree add failed: {stderr}");
-    }
+    let service = WorktreeService::new(RealGitClient, RealZoxideClient);
 
-    // non-TTY: print header before hooks (rm/sync pattern)
-    let created_msg = format!("Created worktree at: {}", display_path(&worktree_path));
-    if !is_tty {
-        eprintln!("{}", color::success(color_mode, &created_msg));
-    }
-
-    // Execute create hooks
-    if !config.hooks.create.run.is_empty()
-        || !config.hooks.create.copy.is_empty()
-        || !config.hooks.create.link.is_empty()
-    {
-        hooks::execute_hooks_lenient_with_mp(
-            &config.hooks.create,
-            &worktree_path,
-            &repo_root,
-            color_mode,
-            "  ",
-            &mp,
-        );
-    }
-
-    // Finish header: Creating → Created
-    if let Some(pb) = header_pb {
-        pb.set_style(ProgressStyle::with_template("{msg}").unwrap());
-        pb.finish_with_message(format!("{}", color::success(color_mode, created_msg)));
-    }
-
-    // Add to zoxide if enabled
-    integrations::zoxide::add_to_zoxide_if_enabled(
+    let hook_actions = &config.hooks.create;
+    let result = service.create_worktree(
+        branch,
         &worktree_path,
-        config.integrations.zoxide.enabled,
-    )?;
+        start_point,
+        &repo_root,
+        zoxide_enabled,
+        |path| {
+            // non-TTY: print "Created..." header before hooks (matches rm/sync pattern)
+            if !is_tty {
+                eprintln!(
+                    "{}",
+                    color::success(
+                        color_mode,
+                        format!("Created worktree at: {}", display_path(path))
+                    )
+                );
+            }
 
-    Ok(())
+            if !hook_actions.run.is_empty()
+                || !hook_actions.copy.is_empty()
+                || !hook_actions.link.is_empty()
+            {
+                hooks::execute_hooks_lenient_with_mp(
+                    hook_actions,
+                    path,
+                    &repo_root,
+                    color_mode,
+                    "  ",
+                    &mp,
+                );
+            }
+
+            Ok(())
+        },
+    );
+
+    match result {
+        Err(e) => {
+            if let Some(pb) = header_pb {
+                pb.finish_and_clear();
+            }
+            Err(e)
+        }
+        Ok(path) => {
+            if let Some(pb) = header_pb {
+                pb.set_style(ProgressStyle::with_template("{msg}").unwrap());
+                pb.finish_with_message(format!(
+                    "{}",
+                    color::success(
+                        color_mode,
+                        format!("Created worktree at: {}", display_path(&path))
+                    )
+                ));
+            }
+            Ok(())
+        }
+    }
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,17 +1,15 @@
 //! List command - Display all worktrees with formatting options
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use chrono::{DateTime, Utc};
 use std::io::IsTerminal;
 use std::path::PathBuf;
-use std::process::Command;
 
 use crate::color;
 use crate::commands::common::get_main_repo_root;
 use crate::config::Config;
-use crate::domain::worktree::{
-    format_worktree_table, get_last_commit_time, normalize_absolute_path, WorktreeList,
-};
+use crate::domain::worktree::{format_worktree_table, normalize_absolute_path, WorktreeList};
+use crate::integrations::git::{GitClient, RealGitClient};
 
 /// List all worktrees
 ///
@@ -21,17 +19,8 @@ use crate::domain::worktree::{
 /// - Output parsing fails
 pub fn cmd_list(show_path: bool, color_mode: color::ColorMode) -> Result<()> {
     // Get worktree list in porcelain format
-    let output = Command::new("git")
-        .args(["worktree", "list", "--porcelain"])
-        .output()
-        .context("Failed to execute git worktree list --porcelain")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git worktree list failed: {stderr}");
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let git = RealGitClient;
+    let stdout = git.list_worktrees(None)?;
 
     // Get current directory for active worktree detection
     let current_dir = std::env::current_dir().ok();
@@ -53,7 +42,7 @@ pub fn cmd_list(show_path: bool, color_mode: color::ColorMode) -> Result<()> {
         // Get commit times for all worktrees
         let commit_times: Vec<Option<DateTime<Utc>>> = entries
             .iter()
-            .map(|entry| get_last_commit_time(&std::path::PathBuf::from(&entry.path)))
+            .map(|entry| git.last_commit_time(&std::path::PathBuf::from(&entry.path)))
             .collect();
 
         // Format and print table to stderr (color_mode controls ANSI emission)
@@ -76,7 +65,7 @@ pub fn cmd_list(show_path: bool, color_mode: color::ColorMode) -> Result<()> {
 
             let commit_times: Vec<Option<DateTime<Utc>>> = entries
                 .iter()
-                .map(|entry| get_last_commit_time(&std::path::PathBuf::from(&entry.path)))
+                .map(|entry| git.last_commit_time(&std::path::PathBuf::from(&entry.path)))
                 .collect();
 
             // Format and print table to stdout

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -10,6 +10,7 @@ use crate::config;
 use crate::domain::worktree::{
     calculate_relative_path, calculate_worktree_root_from_paths, WorktreeList,
 };
+use crate::integrations::git::{GitClient, RealGitClient};
 use crate::integrations::tmux::{sanitize_window_name, RealTmuxLauncher, TmuxLauncher};
 
 /// Worktree entry for the open command
@@ -34,18 +35,11 @@ fn resolve_mode(pane: bool, window: bool, config_value: &str) -> &'static str {
 
 /// Get the current worktree path via git rev-parse --show-toplevel
 fn get_current_worktree_path() -> Result<PathBuf> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .context("Failed to get current worktree path")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("Not in a git repository: {stderr}");
-    }
-
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    Ok(PathBuf::from(path))
+    let git = RealGitClient;
+    let stdout = git
+        .rev_parse(&["rev-parse", "--show-toplevel"], None)
+        .map_err(|e| anyhow::anyhow!("Not in a git repository: {e}"))?;
+    Ok(PathBuf::from(stdout.trim()))
 }
 
 /// Build worktree list with names, skipping the current worktree
@@ -114,18 +108,8 @@ pub fn cmd_open(pane: bool, window: bool, color_mode: color::ColorMode) -> Resul
     launcher.detect()?;
 
     // Get worktree list
-    let output = Command::new("git")
-        .args(["worktree", "list", "--porcelain"])
-        .current_dir(&repo_root)
-        .output()
-        .map_err(|e| anyhow::anyhow!("Failed to execute git worktree list: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git worktree list failed: {}", stderr.trim());
-    }
-
-    let list_stdout = String::from_utf8_lossy(&output.stdout);
+    let git = RealGitClient;
+    let list_stdout = git.list_worktrees(Some(&repo_root))?;
     let list = WorktreeList::parse(&list_stdout, None);
     let main_entry = list
         .main()

--- a/src/commands/rm.rs
+++ b/src/commands/rm.rs
@@ -3,7 +3,6 @@
 use anyhow::{Context, Result};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use std::collections::HashSet;
-use std::process::Command;
 use std::time::Duration;
 
 use crate::color;
@@ -13,6 +12,7 @@ use crate::domain::worktree::{display_path, WorktreeList};
 use crate::hooks;
 use crate::integrations;
 use crate::integrations::fzf::FzfPicker;
+use crate::integrations::git::{GitClient, RealGitClient};
 
 /// Remove a worktree and optionally delete its branch
 /// This is a shared helper function used by both `cmd_rm_many` and `cmd_finish`
@@ -61,20 +61,13 @@ fn remove_worktree_internal(
     }
 
     // Remove worktree using git worktree remove
-    let output = Command::new("git")
-        .args(["worktree", "remove"])
-        .arg(worktree_path)
-        .current_dir(repo_root)
-        .output()
-        .context("Failed to execute git worktree remove")?;
-
-    if !output.status.success() {
+    let git = RealGitClient;
+    if let Err(e) = git.remove_worktree(worktree_path, Some(repo_root)) {
         // Clear header spinner on error
         if let Some(pb) = header_pb {
             pb.finish_and_clear();
         }
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git worktree remove failed: {stderr}");
+        return Err(e);
     }
 
     // Finish header: Removing → Removed
@@ -88,13 +81,7 @@ fn remove_worktree_internal(
 
     // Try to delete the branch (optional, may fail if branch doesn't exist)
     if let Some(branch) = branch_name {
-        let branch_output = Command::new("git")
-            .args(["branch", "-D", branch])
-            .current_dir(repo_root)
-            .output()
-            .context("Failed to execute git branch -D")?;
-
-        if branch_output.status.success() {
+        if git.remove_branch(branch, Some(repo_root)).unwrap_or(false) {
             hooks::emit_line(
                 mp,
                 is_tty,
@@ -126,18 +113,8 @@ pub fn cmd_rm_many(targets: &[String], color_mode: color::ColorMode) -> Result<(
     let config = config::Config::load_from_repo_root(&repo_root)?;
 
     // Get worktree list once for all targets
-    let list_output = Command::new("git")
-        .args(["worktree", "list", "--porcelain"])
-        .current_dir(&repo_root)
-        .output()
-        .context("Failed to execute git worktree list --porcelain")?;
-
-    if !list_output.status.success() {
-        let stderr = String::from_utf8_lossy(&list_output.stderr);
-        anyhow::bail!("git worktree list failed: {stderr}");
-    }
-
-    let list_stdout = String::from_utf8_lossy(&list_output.stdout);
+    let git = RealGitClient;
+    let list_stdout = git.list_worktrees(Some(&repo_root))?;
 
     // Resolve targets: CLI args > stdin (when piped) > fzf
     let targets: Vec<String> = if targets.is_empty() {

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -3,7 +3,6 @@
 use anyhow::Result;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use std::path::Path;
-use std::process::Command;
 use std::time::Duration;
 
 use crate::color;
@@ -11,6 +10,7 @@ use crate::commands::common::get_main_repo_root;
 use crate::config::{self, HookActions};
 use crate::domain::worktree::WorktreeList;
 use crate::hooks;
+use crate::integrations::git::{GitClient, RealGitClient};
 
 /// Sync hooks.create actions to all existing non-main worktrees
 ///
@@ -41,18 +41,8 @@ pub fn cmd_sync(run: bool, copy: bool, link: bool, color_mode: color::ColorMode)
         return Ok(());
     }
 
-    let output = Command::new("git")
-        .args(["worktree", "list", "--porcelain"])
-        .current_dir(&repo_root)
-        .output()
-        .map_err(|e| anyhow::anyhow!("Failed to execute git worktree list: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git worktree list failed: {}", stderr.trim());
-    }
-
-    let list_stdout = String::from_utf8_lossy(&output.stdout);
+    let git = RealGitClient;
+    let list_stdout = git.list_worktrees(Some(&repo_root))?;
     let list = WorktreeList::parse(&list_stdout, None);
     let worktrees = list.non_main();
 

--- a/src/domain/worktree.rs
+++ b/src/domain/worktree.rs
@@ -4,7 +4,6 @@
 
 use chrono::{DateTime, Utc};
 use chrono_humanize::{Accuracy, HumanTime, Tense};
-use std::process::Command;
 
 use crate::color;
 use crate::commands::common::canonicalize_allow_missing;
@@ -170,32 +169,6 @@ impl WorktreeList {
     pub fn current(&self) -> Option<&WorktreeEntry> {
         self.entries.iter().find(|e| e.is_active)
     }
-}
-
-/// Get the last commit time for a worktree
-///
-/// Returns None if the worktree has no commits or if git command fails
-#[must_use]
-pub fn get_last_commit_time(worktree_path: &std::path::Path) -> Option<DateTime<Utc>> {
-    let output = Command::new("git")
-        .args([
-            "-C",
-            &worktree_path.display().to_string(),
-            "log",
-            "-1",
-            "--format=%ct",
-        ])
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let timestamp_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let timestamp: i64 = timestamp_str.parse().ok()?;
-
-    DateTime::from_timestamp(timestamp, 0)
 }
 
 /// Lexically normalize a path by resolving `.` and `..` components
@@ -885,23 +858,6 @@ mod tests {
             let result = display_path(&home);
             assert_eq!(result, "~");
         }
-    }
-
-    #[test]
-    fn test_get_last_commit_time_current_repo() {
-        // Test with current repository (should have commits)
-        let current_dir = std::env::current_dir().unwrap();
-        let result = get_last_commit_time(&current_dir);
-        // Current repo should have commits
-        assert!(result.is_some(), "Current repository should have commits");
-    }
-
-    #[test]
-    fn test_get_last_commit_time_nonexistent_path() {
-        // Test with non-existent path (should return None)
-        let nonexistent = std::path::PathBuf::from("/nonexistent/path/to/worktree");
-        let result = get_last_commit_time(&nonexistent);
-        assert!(result.is_none(), "Non-existent path should return None");
     }
 
     #[test]

--- a/src/integrations/git.rs
+++ b/src/integrations/git.rs
@@ -1,46 +1,96 @@
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::must_use_candidate)]
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 use std::path::Path;
 use std::process::Command;
 
-/// Git client interface for worktree operations
-#[allow(dead_code)]
+/// Git client interface for git operations.
+///
+/// Methods that take `dir: Option<&Path>` use `dir` as the working
+/// directory when `Some`, falling back to the current process working
+/// directory when `None`.
 pub trait GitClient {
-    /// Create a new worktree
+    /// Create a worktree at `path`.
     ///
-    /// # Arguments
-    /// * `branch` - Branch name to create
-    /// * `path` - Path where the worktree will be created
-    /// * `start_point` - Optional start point (branch, tag, or commit)
-    fn create_worktree(&self, branch: &str, path: &Path, start_point: Option<&str>) -> Result<()>;
+    /// When `start_point` is `Some`, runs `git worktree add -b <branch> <path> <start>`.
+    /// When `start_point` is `None`, the implementation checks whether `branch`
+    /// already exists; if so, runs `git worktree add <path> <branch>`,
+    /// otherwise `git worktree add -b <branch> <path>`.
+    fn create_worktree(
+        &self,
+        branch: &str,
+        path: &Path,
+        start_point: Option<&str>,
+        dir: Option<&Path>,
+    ) -> Result<()>;
 
-    /// List all worktrees in porcelain format
-    fn list_worktrees(&self) -> Result<String>;
+    /// Run `git worktree list --porcelain`.
+    fn list_worktrees(&self, dir: Option<&Path>) -> Result<String>;
 
-    /// Remove a worktree
-    fn remove_worktree(&self, path: &Path) -> Result<()>;
+    /// Run `git worktree remove <path>`.
+    fn remove_worktree(&self, path: &Path, dir: Option<&Path>) -> Result<()>;
 
-    /// Remove a branch
-    fn remove_branch(&self, branch: &str) -> Result<()>;
+    /// Run `git branch -D <branch>`.
+    ///
+    /// Returns `Ok(true)` on success, `Ok(false)` when git exits non-zero
+    /// (lenient case used by callers that treat deletion failure as a warning),
+    /// and `Err` only when the git process cannot be spawned.
+    fn remove_branch(&self, branch: &str, dir: Option<&Path>) -> Result<bool>;
+
+    /// Run `git rev-parse --verify <ref>` and return whether it succeeded.
+    ///
+    /// Spawn failures are treated as `false` to match existing call-site
+    /// semantics that use `is_ok_and(|o| o.status.success())`.
+    fn branch_exists(&self, ref_: &str, dir: Option<&Path>) -> bool;
+
+    /// Run `git <args>` (caller supplies the full argument list including
+    /// `rev-parse`) and return stdout on success.
+    fn rev_parse(&self, args: &[&str], dir: Option<&Path>) -> Result<String>;
+
+    /// Run `git <args>` (caller supplies the full argument list including
+    /// `fetch`).
+    fn fetch(&self, args: &[&str], dir: Option<&Path>) -> Result<()>;
+
+    /// Run `git for-each-ref --format=<format> <refs...>` and return stdout.
+    fn for_each_ref(&self, refs: &[&str], format: &str) -> Result<String>;
+
+    /// Run `git -C <worktree_path> log -1 --format=%ct` and return the
+    /// resulting timestamp. Returns `None` for any failure (spawn / non-zero
+    /// exit / parse) to preserve the prior `domain::worktree::get_last_commit_time`
+    /// silent-failure semantics.
+    fn last_commit_time(&self, worktree_path: &Path) -> Option<DateTime<Utc>>;
 }
 
-/// Real git implementation
-#[allow(dead_code)]
+/// Real git implementation. Zero-sized type.
 #[derive(Debug, Default)]
 pub struct RealGitClient;
 
+fn build_command(dir: Option<&Path>) -> Command {
+    let mut cmd = Command::new("git");
+    if let Some(d) = dir {
+        cmd.current_dir(d);
+    }
+    cmd
+}
+
 impl GitClient for RealGitClient {
-    fn create_worktree(&self, branch: &str, path: &Path, start_point: Option<&str>) -> Result<()> {
-        let mut cmd = Command::new("git");
-        cmd.arg("worktree")
-            .arg("add")
-            .arg("-b")
-            .arg(branch)
-            .arg(path);
+    fn create_worktree(
+        &self,
+        branch: &str,
+        path: &Path,
+        start_point: Option<&str>,
+        dir: Option<&Path>,
+    ) -> Result<()> {
+        let mut cmd = build_command(dir);
+        cmd.arg("worktree").arg("add");
 
         if let Some(start) = start_point {
-            cmd.arg(start);
+            cmd.arg("-b").arg(branch).arg(path).arg(start);
+        } else if self.branch_exists(branch, dir) {
+            cmd.arg(path).arg(branch);
+        } else {
+            cmd.arg("-b").arg(branch).arg(path);
         }
 
         let output = cmd.output().context("Failed to execute git worktree add")?;
@@ -53,8 +103,9 @@ impl GitClient for RealGitClient {
         Ok(())
     }
 
-    fn list_worktrees(&self) -> Result<String> {
-        let output = Command::new("git")
+    fn list_worktrees(&self, dir: Option<&Path>) -> Result<String> {
+        let mut cmd = build_command(dir);
+        let output = cmd
             .args(["worktree", "list", "--porcelain"])
             .output()
             .context("Failed to execute git worktree list")?;
@@ -64,13 +115,15 @@ impl GitClient for RealGitClient {
             anyhow::bail!("git worktree list failed: {stderr}");
         }
 
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        Ok(stdout)
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
     }
 
-    fn remove_worktree(&self, path: &Path) -> Result<()> {
-        let output = Command::new("git")
-            .args(["worktree", "remove", &path.display().to_string()])
+    fn remove_worktree(&self, path: &Path, dir: Option<&Path>) -> Result<()> {
+        let mut cmd = build_command(dir);
+        let output = cmd
+            .arg("worktree")
+            .arg("remove")
+            .arg(path)
             .output()
             .context("Failed to execute git worktree remove")?;
 
@@ -82,48 +135,118 @@ impl GitClient for RealGitClient {
         Ok(())
     }
 
-    fn remove_branch(&self, branch: &str) -> Result<()> {
-        let output = Command::new("git")
+    fn remove_branch(&self, branch: &str, dir: Option<&Path>) -> Result<bool> {
+        let mut cmd = build_command(dir);
+        let output = cmd
             .args(["branch", "-D", branch])
             .output()
             .context("Failed to execute git branch -D")?;
 
+        Ok(output.status.success())
+    }
+
+    fn branch_exists(&self, ref_: &str, dir: Option<&Path>) -> bool {
+        let mut cmd = build_command(dir);
+        cmd.args(["rev-parse", "--verify", ref_])
+            .output()
+            .is_ok_and(|o| o.status.success())
+    }
+
+    fn rev_parse(&self, args: &[&str], dir: Option<&Path>) -> Result<String> {
+        let mut cmd = build_command(dir);
+        let output = cmd
+            .args(args)
+            .output()
+            .context("Failed to execute git rev-parse")?;
+
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("git branch -D failed: {stderr}");
+            anyhow::bail!("git rev-parse failed: {stderr}");
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+
+    fn fetch(&self, args: &[&str], dir: Option<&Path>) -> Result<()> {
+        let mut cmd = build_command(dir);
+        let output = cmd
+            .args(args)
+            .output()
+            .context("Failed to execute git fetch")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("git fetch failed: {stderr}");
         }
 
         Ok(())
     }
+
+    fn for_each_ref(&self, refs: &[&str], format: &str) -> Result<String> {
+        let output = Command::new("git")
+            .arg("for-each-ref")
+            .arg(format!("--format={format}"))
+            .args(refs)
+            .output()
+            .context("Failed to execute git for-each-ref")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("git for-each-ref failed: {stderr}");
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+
+    fn last_commit_time(&self, worktree_path: &Path) -> Option<DateTime<Utc>> {
+        let output = Command::new("git")
+            .args([
+                "-C",
+                &worktree_path.display().to_string(),
+                "log",
+                "-1",
+                "--format=%ct",
+            ])
+            .output()
+            .ok()?;
+
+        if !output.status.success() {
+            return None;
+        }
+
+        let timestamp_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let timestamp: i64 = timestamp_str.parse().ok()?;
+
+        DateTime::from_timestamp(timestamp, 0)
+    }
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    /// Mock git client for testing
-    struct MockGitClient {
-        create_should_fail: bool,
-        list_output: String,
-        remove_worktree_should_fail: bool,
-        remove_branch_should_fail: bool,
-    }
-
-    impl MockGitClient {
-        fn new() -> Self {
-            Self {
-                create_should_fail: false,
-                list_output: String::new(),
-                remove_worktree_should_fail: false,
-                remove_branch_should_fail: false,
-            }
-        }
-
-        fn with_list_output(mut self, output: String) -> Self {
-            self.list_output = output;
-            self
-        }
+    /// Mock git client for testing.
+    ///
+    /// Construct with `MockGitClient::default()` and override individual
+    /// fields with struct-update syntax:
+    ///
+    /// ```ignore
+    /// MockGitClient { create_should_fail: true, ..Default::default() }
+    /// ```
+    #[derive(Default)]
+    #[allow(clippy::struct_excessive_bools)]
+    pub struct MockGitClient {
+        pub create_should_fail: bool,
+        pub list_output: String,
+        pub remove_worktree_should_fail: bool,
+        pub remove_branch_returns: bool,
+        pub branch_exists_value: bool,
+        pub rev_parse_output: String,
+        pub rev_parse_should_fail: bool,
+        pub fetch_should_fail: bool,
+        pub for_each_ref_output: String,
+        pub last_commit_time_value: Option<DateTime<Utc>>,
     }
 
     impl GitClient for MockGitClient {
@@ -132,6 +255,7 @@ mod tests {
             _branch: &str,
             _path: &Path,
             _start_point: Option<&str>,
+            _dir: Option<&Path>,
         ) -> Result<()> {
             if self.create_should_fail {
                 anyhow::bail!("Mock git create worktree failure");
@@ -139,62 +263,121 @@ mod tests {
             Ok(())
         }
 
-        fn list_worktrees(&self) -> Result<String> {
+        fn list_worktrees(&self, _dir: Option<&Path>) -> Result<String> {
             Ok(self.list_output.clone())
         }
 
-        fn remove_worktree(&self, _path: &Path) -> Result<()> {
+        fn remove_worktree(&self, _path: &Path, _dir: Option<&Path>) -> Result<()> {
             if self.remove_worktree_should_fail {
                 anyhow::bail!("Mock git remove worktree failure");
             }
             Ok(())
         }
 
-        fn remove_branch(&self, _branch: &str) -> Result<()> {
-            if self.remove_branch_should_fail {
-                anyhow::bail!("Mock git remove branch failure");
+        fn remove_branch(&self, _branch: &str, _dir: Option<&Path>) -> Result<bool> {
+            Ok(self.remove_branch_returns)
+        }
+
+        fn branch_exists(&self, _ref_: &str, _dir: Option<&Path>) -> bool {
+            self.branch_exists_value
+        }
+
+        fn rev_parse(&self, _args: &[&str], _dir: Option<&Path>) -> Result<String> {
+            if self.rev_parse_should_fail {
+                anyhow::bail!("Mock git rev-parse failure");
+            }
+            Ok(self.rev_parse_output.clone())
+        }
+
+        fn fetch(&self, _args: &[&str], _dir: Option<&Path>) -> Result<()> {
+            if self.fetch_should_fail {
+                anyhow::bail!("Mock git fetch failure");
             }
             Ok(())
+        }
+
+        fn for_each_ref(&self, _refs: &[&str], _format: &str) -> Result<String> {
+            Ok(self.for_each_ref_output.clone())
+        }
+
+        fn last_commit_time(&self, _worktree_path: &Path) -> Option<DateTime<Utc>> {
+            self.last_commit_time_value
         }
     }
 
     #[test]
     fn test_mock_git_client_create_worktree_success() {
-        let client = MockGitClient::new();
+        let client = MockGitClient::default();
         let path = PathBuf::from("/test/worktree");
-        let result = client.create_worktree("feature", &path, None);
+        let result = client.create_worktree("feature", &path, None, None);
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_mock_git_client_create_worktree_with_start_point() {
-        let client = MockGitClient::new();
+        let client = MockGitClient::default();
         let path = PathBuf::from("/test/worktree");
-        let result = client.create_worktree("feature", &path, Some("main"));
+        let result = client.create_worktree("feature", &path, Some("main"), Some(Path::new(".")));
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_mock_git_client_list_worktrees() {
         let expected_output = "worktree /path/to/worktree\nbranch refs/heads/main\n";
-        let client = MockGitClient::new().with_list_output(expected_output.to_string());
-        let result = client.list_worktrees();
+        let client = MockGitClient {
+            list_output: expected_output.to_string(),
+            ..Default::default()
+        };
+        let result = client.list_worktrees(None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), expected_output);
     }
 
     #[test]
     fn test_mock_git_client_remove_worktree_success() {
-        let client = MockGitClient::new();
+        let client = MockGitClient::default();
         let path = PathBuf::from("/test/worktree");
-        let result = client.remove_worktree(&path);
+        let result = client.remove_worktree(&path, None);
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_mock_git_client_remove_branch_success() {
-        let client = MockGitClient::new();
-        let result = client.remove_branch("feature");
-        assert!(result.is_ok());
+        let client = MockGitClient {
+            remove_branch_returns: true,
+            ..Default::default()
+        };
+        let result = client.remove_branch("feature", None);
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_mock_git_client_last_commit_time_returns_canned_value() {
+        let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        let client = MockGitClient {
+            last_commit_time_value: Some(now),
+            ..Default::default()
+        };
+        let result = client.last_commit_time(Path::new("/any"));
+        assert_eq!(result, Some(now));
+    }
+
+    #[test]
+    fn test_real_git_client_last_commit_time_current_repo() {
+        // Run RealGitClient against the current process working dir, which
+        // during `cargo test` is the project root — a git repository with
+        // commits.
+        let client = RealGitClient;
+        let current_dir = std::env::current_dir().unwrap();
+        let result = client.last_commit_time(&current_dir);
+        assert!(result.is_some(), "Current repository should have commits");
+    }
+
+    #[test]
+    fn test_real_git_client_last_commit_time_nonexistent_path() {
+        let client = RealGitClient;
+        let nonexistent = std::path::PathBuf::from("/nonexistent/path/to/worktree");
+        let result = client.last_commit_time(&nonexistent);
+        assert!(result.is_none(), "Non-existent path should return None");
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,71 +2,60 @@
 use anyhow::Result;
 use std::path::{Path, PathBuf};
 
-use crate::config::HookActions;
-use crate::hooks::HookExecutor;
 use crate::integrations::git::GitClient;
 use crate::integrations::zoxide::ZoxideClient;
 
-/// Worktree service that coordinates git operations, hooks, and zoxide
-#[allow(dead_code)]
-pub struct WorktreeService<G, H, Z>
+/// Worktree service that coordinates git creation and zoxide registration.
+///
+/// Hook execution is delegated to the caller via the `on_after_git`
+/// callback so the service stays free of UI state (`MultiProgress`,
+/// color mode, etc.).
+pub struct WorktreeService<G, Z>
 where
     G: GitClient,
-    H: HookExecutor,
     Z: ZoxideClient,
 {
     git_client: G,
-    hook_executor: H,
     zoxide_client: Z,
 }
 
-impl<G, H, Z> WorktreeService<G, H, Z>
+impl<G, Z> WorktreeService<G, Z>
 where
     G: GitClient,
-    H: HookExecutor,
     Z: ZoxideClient,
 {
-    /// Create a new worktree service
-    #[allow(dead_code)]
-    pub const fn new(git_client: G, hook_executor: H, zoxide_client: Z) -> Self {
+    pub const fn new(git_client: G, zoxide_client: Z) -> Self {
         Self {
             git_client,
-            hook_executor,
             zoxide_client,
         }
     }
 
-    /// Create a new worktree with hooks and zoxide integration
-    #[allow(dead_code)]
+    /// Create a worktree, then run `on_after_git`, then register with
+    /// zoxide when enabled.
     ///
-    /// # Arguments
-    /// * `branch` - Branch name for the new worktree
-    /// * `worktree_path` - Path where the worktree will be created
-    /// * `start_point` - Optional start point (branch, tag, or commit)
-    /// * `repo_root` - Main repository root path
-    /// * `hooks` - Hook actions to execute after creation
-    /// * `zoxide_enabled` - Whether to add the worktree to zoxide
-    ///
-    /// # Returns
-    /// The path to the created worktree
-    pub fn create_worktree(
+    /// The callback runs after `git worktree add` succeeds and before
+    /// zoxide registration; it is the caller's hook for printing
+    /// progress messages and executing user-defined create hooks.
+    /// Returning `Err` from the callback aborts the flow before zoxide
+    /// is touched.
+    pub fn create_worktree<F>(
         &self,
         branch: &str,
         worktree_path: &Path,
         start_point: Option<&str>,
         repo_root: &Path,
-        hooks: &HookActions,
         zoxide_enabled: bool,
-    ) -> Result<PathBuf> {
-        // Create worktree using git
+        on_after_git: F,
+    ) -> Result<PathBuf>
+    where
+        F: FnOnce(&Path) -> Result<()>,
+    {
         self.git_client
-            .create_worktree(branch, worktree_path, start_point)?;
+            .create_worktree(branch, worktree_path, start_point, Some(repo_root))?;
 
-        // Execute create hooks
-        self.hook_executor
-            .execute_hooks(hooks, worktree_path, repo_root)?;
+        on_after_git(worktree_path)?;
 
-        // Add to zoxide if enabled
         if zoxide_enabled {
             self.zoxide_client.add(worktree_path)?;
         }
@@ -78,76 +67,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::integrations::git::tests::MockGitClient;
+    use std::cell::Cell;
     use std::path::PathBuf;
-
-    // Mock implementations for testing
-    struct MockGitClient {
-        should_fail: bool,
-    }
-
-    impl MockGitClient {
-        fn new() -> Self {
-            Self { should_fail: false }
-        }
-
-        fn with_failure() -> Self {
-            Self { should_fail: true }
-        }
-    }
-
-    impl GitClient for MockGitClient {
-        fn create_worktree(
-            &self,
-            _branch: &str,
-            _path: &Path,
-            _start_point: Option<&str>,
-        ) -> Result<()> {
-            if self.should_fail {
-                anyhow::bail!("Mock git failure");
-            }
-            Ok(())
-        }
-
-        fn list_worktrees(&self) -> Result<String> {
-            Ok(String::new())
-        }
-
-        fn remove_worktree(&self, _path: &Path) -> Result<()> {
-            Ok(())
-        }
-
-        fn remove_branch(&self, _branch: &str) -> Result<()> {
-            Ok(())
-        }
-    }
-
-    struct MockHookExecutor {
-        should_fail: bool,
-    }
-
-    impl MockHookExecutor {
-        fn new() -> Self {
-            Self { should_fail: false }
-        }
-
-        fn with_failure() -> Self {
-            Self { should_fail: true }
-        }
-    }
-
-    impl HookExecutor for MockHookExecutor {
-        fn execute_hooks(
-            &self,
-            _actions: &HookActions,
-            _worktree_path: &Path,
-            _source_path: &Path,
-        ) -> Result<()> {
-            if self.should_fail {
-                anyhow::bail!("Mock hook failure");
-            }
-            Ok(())
-        }
-    }
 
     struct MockZoxideClient {
         should_fail: bool,
@@ -174,24 +96,17 @@ mod tests {
 
     #[test]
     fn test_create_worktree_success() {
-        let service = WorktreeService::new(
-            MockGitClient::new(),
-            MockHookExecutor::new(),
-            MockZoxideClient::new(),
-        );
-
-        let branch = "feature";
+        let service = WorktreeService::new(MockGitClient::default(), MockZoxideClient::new());
         let worktree_path = PathBuf::from("/test/worktree");
         let repo_root = PathBuf::from("/test/repo");
-        let hooks = HookActions::default();
 
         let result = service.create_worktree(
-            branch,
+            "feature",
             &worktree_path,
             None,
             &repo_root,
-            &hooks,
-            true, // zoxide enabled
+            true,
+            |_| Ok(()),
         );
 
         assert!(result.is_ok());
@@ -200,24 +115,17 @@ mod tests {
 
     #[test]
     fn test_create_worktree_with_start_point() {
-        let service = WorktreeService::new(
-            MockGitClient::new(),
-            MockHookExecutor::new(),
-            MockZoxideClient::new(),
-        );
-
-        let branch = "feature";
+        let service = WorktreeService::new(MockGitClient::default(), MockZoxideClient::new());
         let worktree_path = PathBuf::from("/test/worktree");
         let repo_root = PathBuf::from("/test/repo");
-        let hooks = HookActions::default();
 
         let result = service.create_worktree(
-            branch,
+            "feature",
             &worktree_path,
             Some("main"),
             &repo_root,
-            &hooks,
-            false, // zoxide disabled
+            false,
+            |_| Ok(()),
         );
 
         assert!(result.is_ok());
@@ -225,68 +133,67 @@ mod tests {
     }
 
     #[test]
-    fn test_create_worktree_git_failure() {
+    fn test_create_worktree_git_failure_skips_callback_and_zoxide() {
         let service = WorktreeService::new(
-            MockGitClient::with_failure(),
-            MockHookExecutor::new(),
-            MockZoxideClient::new(),
+            MockGitClient {
+                create_should_fail: true,
+                ..Default::default()
+            },
+            MockZoxideClient::with_failure(),
         );
-
-        let branch = "feature";
+        let callback_called = Cell::new(false);
         let worktree_path = PathBuf::from("/test/worktree");
         let repo_root = PathBuf::from("/test/repo");
-        let hooks = HookActions::default();
 
         let result =
-            service.create_worktree(branch, &worktree_path, None, &repo_root, &hooks, true);
-
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Mock git failure"));
-    }
-
-    #[test]
-    fn test_create_worktree_hook_failure() {
-        let service = WorktreeService::new(
-            MockGitClient::new(),
-            MockHookExecutor::with_failure(),
-            MockZoxideClient::new(),
-        );
-
-        let branch = "feature";
-        let worktree_path = PathBuf::from("/test/worktree");
-        let repo_root = PathBuf::from("/test/repo");
-        let hooks = HookActions::default();
-
-        let result =
-            service.create_worktree(branch, &worktree_path, None, &repo_root, &hooks, true);
+            service.create_worktree("feature", &worktree_path, None, &repo_root, true, |_| {
+                callback_called.set(true);
+                Ok(())
+            });
 
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("Mock hook failure"));
+            .contains("Mock git create worktree failure"));
+        assert!(
+            !callback_called.get(),
+            "callback must not run when git fails"
+        );
+    }
+
+    #[test]
+    fn test_create_worktree_callback_error_propagates_and_skips_zoxide() {
+        let service = WorktreeService::new(
+            MockGitClient::default(),
+            MockZoxideClient::with_failure(), // would fail if reached
+        );
+        let worktree_path = PathBuf::from("/test/worktree");
+        let repo_root = PathBuf::from("/test/repo");
+
+        let result =
+            service.create_worktree("feature", &worktree_path, None, &repo_root, true, |_| {
+                anyhow::bail!("callback boom")
+            });
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("callback boom"));
     }
 
     #[test]
     fn test_create_worktree_zoxide_failure() {
-        let service = WorktreeService::new(
-            MockGitClient::new(),
-            MockHookExecutor::new(),
-            MockZoxideClient::with_failure(),
-        );
-
-        let branch = "feature";
+        let service =
+            WorktreeService::new(MockGitClient::default(), MockZoxideClient::with_failure());
         let worktree_path = PathBuf::from("/test/worktree");
         let repo_root = PathBuf::from("/test/repo");
-        let hooks = HookActions::default();
 
         let result = service.create_worktree(
-            branch,
+            "feature",
             &worktree_path,
             None,
             &repo_root,
-            &hooks,
             true, // zoxide enabled
+            |_| Ok(()),
         );
 
         assert!(result.is_err());
@@ -297,25 +204,21 @@ mod tests {
     }
 
     #[test]
-    fn test_create_worktree_zoxide_disabled() {
+    fn test_create_worktree_zoxide_disabled_skips_zoxide() {
         let service = WorktreeService::new(
-            MockGitClient::new(),
-            MockHookExecutor::new(),
-            MockZoxideClient::with_failure(), // Will fail if called
+            MockGitClient::default(),
+            MockZoxideClient::with_failure(), // would fail if reached
         );
-
-        let branch = "feature";
         let worktree_path = PathBuf::from("/test/worktree");
         let repo_root = PathBuf::from("/test/repo");
-        let hooks = HookActions::default();
 
         let result = service.create_worktree(
-            branch,
+            "feature",
             &worktree_path,
             None,
             &repo_root,
-            &hooks,
-            false, // zoxide disabled - should not call zoxide
+            false, // zoxide disabled
+            |_| Ok(()),
         );
 
         assert!(result.is_ok());


### PR DESCRIPTION
## Summary

Completes the Git/Service abstraction documented in the refactoring backlog (Step 3 of the "ofsht refactoring" investigation).

- Extend `GitClient` trait from 4 ops to 9 (`create_worktree`, `list_worktrees`, `remove_worktree`, `remove_branch`, `branch_exists`, `rev_parse`, `fetch`, `for_each_ref`, `last_commit_time`). Each worktree/branch/ref/fetch op takes `dir: Option<&Path>` so callers can scope without relying on inherited cwd.
- Replace all 22 production `Command::new("git")` sites across `commands/`, `cli.rs`, and `domain/worktree.rs` with `RealGitClient` calls. `Command::new("git")` now exists only in `src/integrations/git.rs`.
- Drop `H: HookExecutor` from `WorktreeService` and add an `on_after_git: FnOnce(&Path) -> Result<()>` callback so the service stays free of UI state (`MultiProgress`, color mode, indent). Wire the service into `cmd_create` as the first production caller; the callback runs hooks (lenient) plus the non-TTY "Created" message between `git_add` and `zoxide` registration, preserving the existing output ordering and shell-integration stdout invariant.
- Move `get_last_commit_time` from `domain/worktree.rs` to `RealGitClient::last_commit_time` so the domain layer no longer depends on integrations.
- Share `MockGitClient` via `pub mod tests` for `service.rs::tests` reuse, simplified to `#[derive(Default)]` plus struct-update syntax.
- Remove all `#[allow(dead_code)]` annotations from `service.rs` and `integrations/git.rs` (was 5 total: 3 in `service.rs`, 2 in `integrations/git.rs`).

`cmd_new` continues to call `RealGitClient` directly. Wiring it through `WorktreeService` is deferred to Step 6 (add/create flow unification) where the create header timing and tmux/GitHub paths can be redesigned together. `HookExecutor` production wiring is deferred to Step 4 (hooks.rs split).

## Verification

- `Command::new("git")` now in `src/integrations/git.rs` only (`rg 'Command::new\("git"\)' src/ -l`)
- `#[allow(dead_code)]` count in `service.rs` + `integrations/git.rs`: 5 → 0
- `cargo test`: 623 passed (13 suites); baseline was 621
- `just check`: All checks passed (fmt + clippy strict pedantic/nursery + test-ci)
- `cargo build --release`: green
- Manual smoke (release binary): `ls`, `add` (via stdin), `cd` (stdout-only path output, empty stderr), `rm` (with branch deletion) all behave identically to pre-refactor

## References

- Step 3 of the local refactoring investigation (no public issue)
- Predecessors: #100 (test redistribution), #101 (`WorktreeList` parser unification)
- Follow-ups out of scope for this PR: Step 4 (hooks.rs responsibility split), Step 6 (`add`/`create` flow unification via `CreateWorktreeRequest`)
