### PR TITLE
refactor(service): unify add and create worktree creation flows

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -132,6 +132,7 @@ pub fn list_git_refs(current: &OsStr) -> Vec<CompletionCandidate> {
     let Ok(stdout) = git.for_each_ref(
         &["refs/heads", "refs/remotes", "refs/tags"],
         "%(refname:short)%09%(symref)",
+        None,
     ) else {
         return Vec::new();
     };
@@ -173,6 +174,7 @@ pub fn list_git_branches(current: &OsStr) -> Vec<CompletionCandidate> {
     let Ok(stdout) = git.for_each_ref(
         &["refs/heads", "refs/remotes"],
         "%(refname:short)%09%(symref)",
+        None,
     ) else {
         return Vec::new();
     };

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,6 +1,6 @@
 //! Add command - Create new worktrees with GitHub integration and tmux support
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use std::time::Duration;
 
@@ -11,7 +11,9 @@ use crate::hooks;
 use crate::integrations;
 use crate::integrations::git::{GitClient, RealGitClient};
 use crate::integrations::tmux::TmuxLauncher;
+use crate::integrations::zoxide::{is_zoxide_available, RealZoxideClient};
 use crate::path_utils::normalize_absolute_path;
+use crate::service::{CreateWorktreeRequest, WorktreeService};
 
 /// Process a PR and return branch name and start point
 fn process_pr(
@@ -33,7 +35,7 @@ fn process_pr(
         .map_err(|e| anyhow::anyhow!("git fetch PR ref failed: {e}"))?;
 
         // Check if local branch with PR's name already exists
-        let branch_exists = git.branch_exists(&pr.head_ref_name, Some(repo_root));
+        let branch_exists = git.branch_exists(&pr.head_ref_name, Some(repo_root))?;
 
         eprintln!(
             "{}",
@@ -78,7 +80,7 @@ fn process_pr(
         );
 
         // Check if local branch already exists
-        let branch_exists = git.branch_exists(&pr.head_ref_name, Some(repo_root));
+        let branch_exists = git.branch_exists(&pr.head_ref_name, Some(repo_root))?;
 
         if branch_exists {
             // Existing local branch - use it directly
@@ -219,25 +221,6 @@ pub fn cmd_new(
         let launcher = integrations::tmux::RealTmuxLauncher;
         launcher.detect()?;
     }
-    let repo_name = repo_root
-        .file_name()
-        .and_then(|n| n.to_str())
-        .context("Failed to get repository name")?;
-
-    // Expand path template
-    #[allow(clippy::literal_string_with_formatting_args)]
-    let path_template = config
-        .worktree
-        .dir
-        .replace("{repo}", repo_name)
-        .replace("{branch}", branch);
-
-    // Create worktree path (relative paths are resolved from repo root)
-    let worktree_path = if path_template.starts_with('/') {
-        std::path::PathBuf::from(&path_template)
-    } else {
-        repo_root.join(&path_template)
-    };
 
     let mp = MultiProgress::new();
     let is_tty = color_mode.should_colorize();
@@ -257,34 +240,51 @@ pub fn cmd_new(
         None
     };
 
-    // Create worktree (RealGitClient handles the new/existing-branch dispatch internally)
-    let git = RealGitClient;
-    if let Err(e) = git.create_worktree(branch, &worktree_path, start_point, Some(&repo_root)) {
-        if let Some(pb) = header_pb {
-            pb.finish_and_clear();
+    // Resolve zoxide gating before handing control to the service.
+    let zoxide_enabled = config.integrations.zoxide.enabled && is_zoxide_available();
+
+    let service = WorktreeService::new(RealGitClient, RealZoxideClient);
+    let hook_actions = &config.hooks.create;
+    let req = CreateWorktreeRequest {
+        branch,
+        start_point,
+        repo_root: &repo_root,
+        path_template: &config.worktree.dir,
+        zoxide_enabled,
+    };
+
+    let result = service.create(&req, |path| {
+        // non-TTY: print header before hooks (rm/sync pattern)
+        if !is_tty {
+            eprintln!("{}", color::success(color_mode, format!("Added {branch}")));
         }
-        return Err(e);
-    }
 
-    // non-TTY: print header before hooks (rm/sync pattern)
-    if !is_tty {
-        eprintln!("{}", color::success(color_mode, format!("Added {branch}")));
-    }
+        if !hook_actions.run.is_empty()
+            || !hook_actions.copy.is_empty()
+            || !hook_actions.link.is_empty()
+        {
+            hooks::execute_hooks_lenient_with_mp(
+                hook_actions,
+                path,
+                &repo_root,
+                color_mode,
+                "  ",
+                &mp,
+            );
+        }
 
-    // Execute create hooks
-    if !config.hooks.create.run.is_empty()
-        || !config.hooks.create.copy.is_empty()
-        || !config.hooks.create.link.is_empty()
-    {
-        hooks::execute_hooks_lenient_with_mp(
-            &config.hooks.create,
-            &worktree_path,
-            &repo_root,
-            color_mode,
-            "  ",
-            &mp,
-        );
-    }
+        Ok(())
+    });
+
+    let worktree_path = match result {
+        Err(e) => {
+            if let Some(pb) = header_pb {
+                pb.finish_and_clear();
+            }
+            return Err(e);
+        }
+        Ok(path) => path,
+    };
 
     // Finish header: Adding → Added
     if let Some(pb) = header_pb {
@@ -294,12 +294,6 @@ pub fn cmd_new(
             color::success(color_mode, format!("Added {branch}"))
         ));
     }
-
-    // Add to zoxide if enabled
-    integrations::zoxide::add_to_zoxide_if_enabled(
-        &worktree_path,
-        config.integrations.zoxide.enabled,
-    )?;
 
     // Create tmux window or pane if enabled
     if use_tmux {

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -1,6 +1,6 @@
 //! Create command - Simple worktree creation without extra features
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use std::time::Duration;
 
@@ -11,7 +11,7 @@ use crate::hooks;
 use crate::integrations::git::RealGitClient;
 use crate::integrations::zoxide::{is_zoxide_available, RealZoxideClient};
 use crate::path_utils::display_path;
-use crate::service::WorktreeService;
+use crate::service::{CreateWorktreeRequest, WorktreeService};
 
 /// Create a new worktree (simple version without tmux/GitHub integration)
 ///
@@ -40,25 +40,6 @@ pub fn cmd_create(
 
     // Load configuration from repo root
     let config = config::Config::load_from_repo_root(&repo_root)?;
-    let repo_name = repo_root
-        .file_name()
-        .and_then(|n| n.to_str())
-        .context("Failed to get repository name")?;
-
-    // Expand path template
-    #[allow(clippy::literal_string_with_formatting_args)]
-    let path_template = config
-        .worktree
-        .dir
-        .replace("{repo}", repo_name)
-        .replace("{branch}", branch);
-
-    // Create worktree path (relative paths are resolved from repo root)
-    let worktree_path = if path_template.starts_with('/') {
-        std::path::PathBuf::from(&path_template)
-    } else {
-        repo_root.join(&path_template)
-    };
 
     let mp = MultiProgress::new();
     let is_tty = color_mode.should_colorize();
@@ -85,41 +66,42 @@ pub fn cmd_create(
     let service = WorktreeService::new(RealGitClient, RealZoxideClient);
 
     let hook_actions = &config.hooks.create;
-    let result = service.create_worktree(
+    let req = CreateWorktreeRequest {
         branch,
-        &worktree_path,
         start_point,
-        &repo_root,
+        repo_root: &repo_root,
+        path_template: &config.worktree.dir,
         zoxide_enabled,
-        |path| {
-            // non-TTY: print "Created..." header before hooks (matches rm/sync pattern)
-            if !is_tty {
-                eprintln!(
-                    "{}",
-                    color::success(
-                        color_mode,
-                        format!("Created worktree at: {}", display_path(path))
-                    )
-                );
-            }
+    };
 
-            if !hook_actions.run.is_empty()
-                || !hook_actions.copy.is_empty()
-                || !hook_actions.link.is_empty()
-            {
-                hooks::execute_hooks_lenient_with_mp(
-                    hook_actions,
-                    path,
-                    &repo_root,
+    let result = service.create(&req, |path| {
+        // non-TTY: print "Created..." header before hooks (matches rm/sync pattern)
+        if !is_tty {
+            eprintln!(
+                "{}",
+                color::success(
                     color_mode,
-                    "  ",
-                    &mp,
-                );
-            }
+                    format!("Created worktree at: {}", display_path(path))
+                )
+            );
+        }
 
-            Ok(())
-        },
-    );
+        if !hook_actions.run.is_empty()
+            || !hook_actions.copy.is_empty()
+            || !hook_actions.link.is_empty()
+        {
+            hooks::execute_hooks_lenient_with_mp(
+                hook_actions,
+                path,
+                &repo_root,
+                color_mode,
+                "  ",
+                &mp,
+            );
+        }
+
+        Ok(())
+    });
 
     match result {
         Err(e) => {

--- a/src/integrations/git.rs
+++ b/src/integrations/git.rs
@@ -40,9 +40,10 @@ pub trait GitClient {
 
     /// Run `git rev-parse --verify <ref>` and return whether it succeeded.
     ///
-    /// Spawn failures are treated as `false` to match existing call-site
-    /// semantics that use `is_ok_and(|o| o.status.success())`.
-    fn branch_exists(&self, ref_: &str, dir: Option<&Path>) -> bool;
+    /// Returns `Ok(true)` when the ref exists, `Ok(false)` when git exits
+    /// non-zero (ref does not exist), and `Err` only when the git process
+    /// cannot be spawned.
+    fn branch_exists(&self, ref_: &str, dir: Option<&Path>) -> Result<bool>;
 
     /// Run `git <args>` (caller supplies the full argument list including
     /// `rev-parse`) and return stdout on success.
@@ -53,7 +54,7 @@ pub trait GitClient {
     fn fetch(&self, args: &[&str], dir: Option<&Path>) -> Result<()>;
 
     /// Run `git for-each-ref --format=<format> <refs...>` and return stdout.
-    fn for_each_ref(&self, refs: &[&str], format: &str) -> Result<String>;
+    fn for_each_ref(&self, refs: &[&str], format: &str, dir: Option<&Path>) -> Result<String>;
 
     /// Run `git -C <worktree_path> log -1 --format=%ct` and return the
     /// resulting timestamp. Returns `None` for any failure (spawn / non-zero
@@ -74,6 +75,21 @@ fn build_command(dir: Option<&Path>) -> Command {
     cmd
 }
 
+/// Spawn the configured command, fail with `git {op} failed: ...` on non-zero
+/// exit, and return stdout on success. Centralizes the spawn-context, status
+/// check, and bail pattern shared by every `RealGitClient` method that
+/// propagates errors.
+fn run_capturing(mut cmd: Command, op: &str) -> Result<String> {
+    let output = cmd
+        .output()
+        .with_context(|| format!("Failed to execute git {op}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git {op} failed: {stderr}");
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
 impl GitClient for RealGitClient {
     fn create_worktree(
         &self,
@@ -87,51 +103,26 @@ impl GitClient for RealGitClient {
 
         if let Some(start) = start_point {
             cmd.arg("-b").arg(branch).arg(path).arg(start);
-        } else if self.branch_exists(branch, dir) {
+        } else if self.branch_exists(branch, dir)? {
             cmd.arg(path).arg(branch);
         } else {
             cmd.arg("-b").arg(branch).arg(path);
         }
 
-        let output = cmd.output().context("Failed to execute git worktree add")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("git worktree add failed: {stderr}");
-        }
-
+        run_capturing(cmd, "worktree add")?;
         Ok(())
     }
 
     fn list_worktrees(&self, dir: Option<&Path>) -> Result<String> {
         let mut cmd = build_command(dir);
-        let output = cmd
-            .args(["worktree", "list", "--porcelain"])
-            .output()
-            .context("Failed to execute git worktree list")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("git worktree list failed: {stderr}");
-        }
-
-        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        cmd.args(["worktree", "list", "--porcelain"]);
+        run_capturing(cmd, "worktree list")
     }
 
     fn remove_worktree(&self, path: &Path, dir: Option<&Path>) -> Result<()> {
         let mut cmd = build_command(dir);
-        let output = cmd
-            .arg("worktree")
-            .arg("remove")
-            .arg(path)
-            .output()
-            .context("Failed to execute git worktree remove")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("git worktree remove failed: {stderr}");
-        }
-
+        cmd.arg("worktree").arg("remove").arg(path);
+        run_capturing(cmd, "worktree remove")?;
         Ok(())
     }
 
@@ -145,57 +136,34 @@ impl GitClient for RealGitClient {
         Ok(output.status.success())
     }
 
-    fn branch_exists(&self, ref_: &str, dir: Option<&Path>) -> bool {
+    fn branch_exists(&self, ref_: &str, dir: Option<&Path>) -> Result<bool> {
         let mut cmd = build_command(dir);
-        cmd.args(["rev-parse", "--verify", ref_])
+        let output = cmd
+            .args(["rev-parse", "--verify", ref_])
             .output()
-            .is_ok_and(|o| o.status.success())
+            .context("Failed to execute git rev-parse --verify")?;
+        Ok(output.status.success())
     }
 
     fn rev_parse(&self, args: &[&str], dir: Option<&Path>) -> Result<String> {
         let mut cmd = build_command(dir);
-        let output = cmd
-            .args(args)
-            .output()
-            .context("Failed to execute git rev-parse")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("git rev-parse failed: {stderr}");
-        }
-
-        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        cmd.args(args);
+        run_capturing(cmd, "rev-parse")
     }
 
     fn fetch(&self, args: &[&str], dir: Option<&Path>) -> Result<()> {
         let mut cmd = build_command(dir);
-        let output = cmd
-            .args(args)
-            .output()
-            .context("Failed to execute git fetch")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("git fetch failed: {stderr}");
-        }
-
+        cmd.args(args);
+        run_capturing(cmd, "fetch")?;
         Ok(())
     }
 
-    fn for_each_ref(&self, refs: &[&str], format: &str) -> Result<String> {
-        let output = Command::new("git")
-            .arg("for-each-ref")
+    fn for_each_ref(&self, refs: &[&str], format: &str, dir: Option<&Path>) -> Result<String> {
+        let mut cmd = build_command(dir);
+        cmd.arg("for-each-ref")
             .arg(format!("--format={format}"))
-            .args(refs)
-            .output()
-            .context("Failed to execute git for-each-ref")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("git for-each-ref failed: {stderr}");
-        }
-
-        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+            .args(refs);
+        run_capturing(cmd, "for-each-ref")
     }
 
     fn last_commit_time(&self, worktree_path: &Path) -> Option<DateTime<Utc>> {
@@ -278,8 +246,8 @@ pub mod tests {
             Ok(self.remove_branch_returns)
         }
 
-        fn branch_exists(&self, _ref_: &str, _dir: Option<&Path>) -> bool {
-            self.branch_exists_value
+        fn branch_exists(&self, _ref_: &str, _dir: Option<&Path>) -> Result<bool> {
+            Ok(self.branch_exists_value)
         }
 
         fn rev_parse(&self, _args: &[&str], _dir: Option<&Path>) -> Result<String> {
@@ -296,7 +264,12 @@ pub mod tests {
             Ok(())
         }
 
-        fn for_each_ref(&self, _refs: &[&str], _format: &str) -> Result<String> {
+        fn for_each_ref(
+            &self,
+            _refs: &[&str],
+            _format: &str,
+            _dir: Option<&Path>,
+        ) -> Result<String> {
             Ok(self.for_each_ref_output.clone())
         }
 

--- a/src/integrations/zoxide.rs
+++ b/src/integrations/zoxide.rs
@@ -38,24 +38,6 @@ pub fn is_zoxide_available() -> bool {
         .is_ok_and(|output| output.status.success())
 }
 
-/// Add a path to zoxide if enabled and available
-///
-/// This function gracefully handles the case where zoxide is not installed.
-/// It will only return an error if zoxide is installed but fails to add the path.
-pub fn add_to_zoxide_if_enabled(path: &Path, enabled: bool) -> Result<()> {
-    if !enabled {
-        return Ok(());
-    }
-
-    if !is_zoxide_available() {
-        // Gracefully skip if zoxide is not installed
-        return Ok(());
-    }
-
-    let client = RealZoxideClient;
-    client.add(path)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -95,31 +77,5 @@ mod tests {
         // This test will pass or fail depending on whether zoxide is installed
         // We're just checking that the function doesn't panic
         let _ = is_zoxide_available();
-    }
-
-    #[test]
-    fn test_add_to_zoxide_if_enabled_disabled() {
-        let path = PathBuf::from("/test/path");
-        let result = add_to_zoxide_if_enabled(&path, false);
-        // Should succeed even if zoxide is not available
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_add_to_zoxide_if_enabled_enabled() {
-        // This test will succeed if:
-        // 1. zoxide is installed and can add the path (success)
-        // 2. zoxide is not installed (gracefully skipped, success)
-        // It may fail if zoxide is installed but returns an error
-        let path = PathBuf::from("/tmp");
-        let result = add_to_zoxide_if_enabled(&path, true);
-
-        if is_zoxide_available() {
-            // If zoxide is available, it should successfully add the path
-            assert!(result.is_ok(), "Failed to add to zoxide: {result:?}");
-        } else {
-            // If zoxide is not available, it should gracefully succeed
-            assert!(result.is_ok());
-        }
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,9 +1,21 @@
 #![allow(clippy::missing_errors_doc)]
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
 use crate::integrations::git::GitClient;
 use crate::integrations::zoxide::ZoxideClient;
+
+/// Request describing where and how to create a worktree.
+///
+/// Borrow-based: the caller owns `branch` / `repo_root` / `path_template`
+/// for the duration of the `WorktreeService::create` call.
+pub struct CreateWorktreeRequest<'a> {
+    pub branch: &'a str,
+    pub start_point: Option<&'a str>,
+    pub repo_root: &'a Path,
+    pub path_template: &'a str,
+    pub zoxide_enabled: bool,
+}
 
 /// Worktree service that coordinates git creation and zoxide registration.
 ///
@@ -31,36 +43,49 @@ where
         }
     }
 
-    /// Create a worktree, then run `on_after_git`, then register with
-    /// zoxide when enabled.
+    /// Create a worktree from `req`: expand the path template, run
+    /// `git worktree add`, invoke `on_after_git` (typically to execute
+    /// user hooks), then register with zoxide when enabled.
     ///
-    /// The callback runs after `git worktree add` succeeds and before
-    /// zoxide registration; it is the caller's hook for printing
-    /// progress messages and executing user-defined create hooks.
-    /// Returning `Err` from the callback aborts the flow before zoxide
-    /// is touched.
-    pub fn create_worktree<F>(
-        &self,
-        branch: &str,
-        worktree_path: &Path,
-        start_point: Option<&str>,
-        repo_root: &Path,
-        zoxide_enabled: bool,
-        on_after_git: F,
-    ) -> Result<PathBuf>
+    /// Returns the worktree path the service computed (the same value
+    /// passed to `on_after_git`). No canonicalization is performed; the
+    /// caller is responsible for normalization at any output boundary.
+    pub fn create<F>(&self, req: &CreateWorktreeRequest<'_>, on_after_git: F) -> Result<PathBuf>
     where
         F: FnOnce(&Path) -> Result<()>,
     {
-        self.git_client
-            .create_worktree(branch, worktree_path, start_point, Some(repo_root))?;
+        let repo_name = req
+            .repo_root
+            .file_name()
+            .and_then(|n| n.to_str())
+            .context("Failed to get repository name")?;
 
-        on_after_git(worktree_path)?;
+        #[allow(clippy::literal_string_with_formatting_args)]
+        let expanded = req
+            .path_template
+            .replace("{repo}", repo_name)
+            .replace("{branch}", req.branch);
 
-        if zoxide_enabled {
-            self.zoxide_client.add(worktree_path)?;
+        let worktree_path = if expanded.starts_with('/') {
+            PathBuf::from(&expanded)
+        } else {
+            req.repo_root.join(&expanded)
+        };
+
+        self.git_client.create_worktree(
+            req.branch,
+            &worktree_path,
+            req.start_point,
+            Some(req.repo_root),
+        )?;
+
+        on_after_git(&worktree_path)?;
+
+        if req.zoxide_enabled {
+            self.zoxide_client.add(&worktree_path)?;
         }
 
-        Ok(worktree_path.to_path_buf())
+        Ok(worktree_path)
     }
 }
 
@@ -94,46 +119,55 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_create_worktree_success() {
-        let service = WorktreeService::new(MockGitClient::default(), MockZoxideClient::new());
-        let worktree_path = PathBuf::from("/test/worktree");
-        let repo_root = PathBuf::from("/test/repo");
-
-        let result = service.create_worktree(
-            "feature",
-            &worktree_path,
-            None,
-            &repo_root,
-            true,
-            |_| Ok(()),
-        );
-
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), worktree_path);
+    fn make_req<'a>(
+        branch: &'a str,
+        repo_root: &'a Path,
+        path_template: &'a str,
+        zoxide_enabled: bool,
+    ) -> CreateWorktreeRequest<'a> {
+        CreateWorktreeRequest {
+            branch,
+            start_point: None,
+            repo_root,
+            path_template,
+            zoxide_enabled,
+        }
     }
 
     #[test]
-    fn test_create_worktree_with_start_point() {
+    fn test_create_success() {
         let service = WorktreeService::new(MockGitClient::default(), MockZoxideClient::new());
-        let worktree_path = PathBuf::from("/test/worktree");
         let repo_root = PathBuf::from("/test/repo");
+        let req = make_req("feature", &repo_root, "../{repo}-worktrees/{branch}", true);
 
-        let result = service.create_worktree(
-            "feature",
-            &worktree_path,
-            Some("main"),
-            &repo_root,
-            false,
-            |_| Ok(()),
-        );
+        let result = service.create(&req, |_| Ok(()));
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), worktree_path);
+        assert_eq!(
+            result.unwrap(),
+            PathBuf::from("/test/repo/../repo-worktrees/feature")
+        );
     }
 
     #[test]
-    fn test_create_worktree_git_failure_skips_callback_and_zoxide() {
+    fn test_create_with_start_point() {
+        let service = WorktreeService::new(MockGitClient::default(), MockZoxideClient::new());
+        let repo_root = PathBuf::from("/test/repo");
+        let req = CreateWorktreeRequest {
+            branch: "feature",
+            start_point: Some("main"),
+            repo_root: &repo_root,
+            path_template: "../{repo}-worktrees/{branch}",
+            zoxide_enabled: false,
+        };
+
+        let result = service.create(&req, |_| Ok(()));
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_create_git_failure_skips_callback_and_zoxide() {
         let service = WorktreeService::new(
             MockGitClient {
                 create_should_fail: true,
@@ -142,14 +176,13 @@ mod tests {
             MockZoxideClient::with_failure(),
         );
         let callback_called = Cell::new(false);
-        let worktree_path = PathBuf::from("/test/worktree");
         let repo_root = PathBuf::from("/test/repo");
+        let req = make_req("feature", &repo_root, "../{repo}-worktrees/{branch}", true);
 
-        let result =
-            service.create_worktree("feature", &worktree_path, None, &repo_root, true, |_| {
-                callback_called.set(true);
-                Ok(())
-            });
+        let result = service.create(&req, |_| {
+            callback_called.set(true);
+            Ok(())
+        });
 
         assert!(result.is_err());
         assert!(result
@@ -163,38 +196,28 @@ mod tests {
     }
 
     #[test]
-    fn test_create_worktree_callback_error_propagates_and_skips_zoxide() {
+    fn test_create_callback_error_propagates_and_skips_zoxide() {
         let service = WorktreeService::new(
             MockGitClient::default(),
             MockZoxideClient::with_failure(), // would fail if reached
         );
-        let worktree_path = PathBuf::from("/test/worktree");
         let repo_root = PathBuf::from("/test/repo");
+        let req = make_req("feature", &repo_root, "../{repo}-worktrees/{branch}", true);
 
-        let result =
-            service.create_worktree("feature", &worktree_path, None, &repo_root, true, |_| {
-                anyhow::bail!("callback boom")
-            });
+        let result = service.create(&req, |_| anyhow::bail!("callback boom"));
 
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("callback boom"));
     }
 
     #[test]
-    fn test_create_worktree_zoxide_failure() {
+    fn test_create_zoxide_failure() {
         let service =
             WorktreeService::new(MockGitClient::default(), MockZoxideClient::with_failure());
-        let worktree_path = PathBuf::from("/test/worktree");
         let repo_root = PathBuf::from("/test/repo");
+        let req = make_req("feature", &repo_root, "../{repo}-worktrees/{branch}", true);
 
-        let result = service.create_worktree(
-            "feature",
-            &worktree_path,
-            None,
-            &repo_root,
-            true, // zoxide enabled
-            |_| Ok(()),
-        );
+        let result = service.create(&req, |_| Ok(()));
 
         assert!(result.is_err());
         assert!(result
@@ -204,24 +227,50 @@ mod tests {
     }
 
     #[test]
-    fn test_create_worktree_zoxide_disabled_skips_zoxide() {
+    fn test_create_zoxide_disabled_skips_zoxide() {
         let service = WorktreeService::new(
             MockGitClient::default(),
             MockZoxideClient::with_failure(), // would fail if reached
         );
-        let worktree_path = PathBuf::from("/test/worktree");
         let repo_root = PathBuf::from("/test/repo");
+        let req = make_req("feature", &repo_root, "../{repo}-worktrees/{branch}", true);
+        let req = CreateWorktreeRequest {
+            zoxide_enabled: false,
+            ..req
+        };
 
-        let result = service.create_worktree(
-            "feature",
-            &worktree_path,
-            None,
-            &repo_root,
-            false, // zoxide disabled
-            |_| Ok(()),
-        );
+        let result = service.create(&req, |_| Ok(()));
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), worktree_path);
+    }
+
+    #[test]
+    fn test_create_expands_relative_template() {
+        let service = WorktreeService::new(MockGitClient::default(), MockZoxideClient::new());
+        let repo_root = PathBuf::from("/Users/me/projects/myrepo");
+        let req = make_req(
+            "feat/auth",
+            &repo_root,
+            "../{repo}-worktrees/{branch}",
+            false,
+        );
+
+        let result = service.create(&req, |_| Ok(())).unwrap();
+
+        assert_eq!(
+            result,
+            PathBuf::from("/Users/me/projects/myrepo/../myrepo-worktrees/feat/auth")
+        );
+    }
+
+    #[test]
+    fn test_create_expands_absolute_template() {
+        let service = WorktreeService::new(MockGitClient::default(), MockZoxideClient::new());
+        let repo_root = PathBuf::from("/Users/me/projects/myrepo");
+        let req = make_req("feature", &repo_root, "/tmp/wt/{repo}/{branch}", false);
+
+        let result = service.create(&req, |_| Ok(())).unwrap();
+
+        assert_eq!(result, PathBuf::from("/tmp/wt/myrepo/feature"));
     }
 }


### PR DESCRIPTION
## Summary

Step 6 of the ongoing refactor (tracked in the personal Obsidian "ofsht リファクタリング観点調査" note): unify the `add` and `create` worktree creation flows so both route through `WorktreeService`. Bundle three deferred SHOULD_FIX items in `integrations/git.rs` so the touch on that file happens once.

- Add `CreateWorktreeRequest<'a>` (5 borrow-based fields) and `WorktreeService::create(&req, callback)` in `service.rs`. The service owns `{repo}` / `{branch}` template expansion plus the absolute / relative branching, then runs `git.create_worktree` → callback (hooks) → zoxide registration.
- Migrate `cmd_new` (the `add` command) and `cmd_create` off the manual git/hooks/zoxide sequence; remove the legacy `WorktreeService::create_worktree`.
- Remove `add_to_zoxide_if_enabled` (caller-zero after migration); `is_zoxide_available` is preserved (still used by `template_generator`).
- `integrations/git.rs` SHOULD_FIX (carried over from PR #102 review):
  - `for_each_ref(refs, format)` gains a `dir: Option<&Path>` parameter.
  - `branch_exists(...)` returns `Result<bool>` instead of `bool`. Spawn failure is no longer silently treated as "branch absent" — `process_pr` (fork PR resolution) now bubbles it up via `?`.
  - Extract a private `run_capturing(cmd, op)` helper and apply it to the six methods that share the spawn / status / bail pattern.

Net diff: **256 insertions / 300 deletions** (-44 lines) despite adding the new request struct and two new path-expansion tests, because the duplicated template-expand + git/hooks/zoxide blocks in both commands are gone.

Behavior preserved (verified by smoke test on the release binary):

- `ofsht add <branch>` still prints the worktree path to stdout, with success messages on stderr.
- `ofsht add <branch>` under tmux still suppresses the stdout path (so the shell wrapper does not `cd`).
- `ofsht create <branch>` still emits nothing on stdout (only stderr success message).
- Hooks order (`run` → `copy` → `link`), stderr-only output, and lenient warnings unchanged — the callback contents in both commands are byte-equivalent.

## Test plan

- [x] `cargo test` — 619 passed (Phase B added 2 path-expansion tests, Phase C removed 2 zoxide tests, net 0)
- [x] `cargo test --doc` — 5 passed
- [x] `just check` — clippy + fmt + test all green
- [x] Smoke (release binary) — `ofsht add smoke-add` and `ofsht create smoke-create` both produce expected stdout / stderr / on-disk worktrees
- [x] `/completion-audit` — VERIFIED PASS
- [x] `/subagent-review` — Spec Compliance / Code Quality / rust-reviewer all PASS (no MUST_FIX)

## References

- Follow-up to #102 (introduced `GitClient` / `WorktreeService` and connected `cmd_create` only)
- Related: #100, #101, #103, #104 (steps 1–5 of the same refactor track)
